### PR TITLE
fix up the pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,8 +3,8 @@
 set -eu
 
 # make the GIT_DIR and GIT_INDEX_FILE absolute, before we change dir
-export GIT_DIR=$(realpath `git rev-parse --git-dir`)
-export GIT_INDEX_FILE=$(realpath `git rev-parse --git-path index`)
+export GIT_DIR=$(readlink -f `git rev-parse --git-dir`)
+export GIT_INDEX_FILE=$(readlink -f `git rev-parse --git-path index`)
 
 wd=`pwd`
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,7 +4,9 @@ set -eu
 
 # make the GIT_DIR and GIT_INDEX_FILE absolute, before we change dir
 export GIT_DIR=$(readlink -f `git rev-parse --git-dir`)
-export GIT_INDEX_FILE=$(readlink -f `git rev-parse --git-path index`)
+if [ -n "${GIT_INDEX_FILE:+x}" ]; then
+    export GIT_INDEX_FILE=$(readlink -f "$GIT_INDEX_FILE")
+fi
 
 wd=`pwd`
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,9 +1,41 @@
-#! /bin/bash
+#!/bin/bash
 
 set -eu
 
+# make the GIT_DIR and GIT_INDEX_FILE absolute, before we change dir
+export GIT_DIR=$(realpath `git rev-parse --git-dir`)
+export GIT_INDEX_FILE=$(realpath `git rev-parse --git-path index`)
+
+wd=`pwd`
+
+# create a temp dir
+tmpdir=`mktemp -d`
+trap 'rm -rf "$tmpdir"' EXIT
+cd "$tmpdir"
+
+# get a copy of the index
+git checkout-index -a
+
+# run our checks
 golint src/...
 go fmt ./src/...
 go tool vet --shadow ./src
 gocyclo -over 12 src/
 gb test
+
+# if there are no changes from the index, we are done
+git diff --quiet && exit 0
+
+# we now need to apply any changes made to both the index and the working copy.
+# so, first get a patch
+git diff > "$GIT_DIR/pre-commit.patch"
+
+# add the changes to the index
+git add -u
+
+# attempt to apply the changes to the wc (but don't fail the commit for it if
+# there are conflicts).
+cd "$wd"
+git apply "$GIT_DIR/pre-commit.patch" 2>/dev/null &&
+    rm "$GIT_DIR/pre-commit.patch" ||
+    echo "warning: unable to apply changes from commit hook to working copy; patch is in $GIT_DIR/pre-commit.patch" >&2

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -8,13 +8,15 @@ export GIT_INDEX_FILE=$(readlink -f `git rev-parse --git-path index`)
 
 wd=`pwd`
 
-# create a temp dir. The `trap` incantaion will ensure that it is removed again
-# when this script completes.
+# create a temp dir. The `trap` incantation will ensure that it is removed
+# again when this script completes.
 tmpdir=`mktemp -d`
 trap 'rm -rf "$tmpdir"' EXIT
 cd "$tmpdir"
 
-# get a copy of the index
+# get a clean copy of the index (ie, what has been `git add`ed), so that we can
+# run the checks against what we are about to commit, rather than what is in
+# the working copy.
 git checkout-index -a
 
 # run our checks

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -8,7 +8,8 @@ export GIT_INDEX_FILE=$(readlink -f `git rev-parse --git-path index`)
 
 wd=`pwd`
 
-# create a temp dir
+# create a temp dir. The `trap` incantaion will ensure that it is removed again
+# when this script completes.
 tmpdir=`mktemp -d`
 trap 'rm -rf "$tmpdir"' EXIT
 cd "$tmpdir"


### PR DESCRIPTION
* Run the checks against the git index (ie, what you're about to commit), rather than the working copy

* Add the changes made by `go fmt` back to the index, so that they are included in the commit, as well as the working copy.