### PR TITLE
Add support for attaching files to reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ logs.)
 
   Compressed logs are not supported for the JSON upload encoding.
 
+* `file`: an arbitrary file to attach to the report. Saved as-is to disk, and
+  a link is added to the github issue.
+
+  Not supported for the JSON upload encoding.
+
 * Any other form field names are interpreted as arbitrary name/value strings to
   include in the `details.log.gz` file.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ logs.)
   Compressed logs are not supported for the JSON upload encoding.
 
 * `file`: an arbitrary file to attach to the report. Saved as-is to disk, and
-  a link is added to the github issue.
+  a link is added to the github issue. The filename must be in the format
+  `name.ext`, where `name` contains only alphanumerics, `-` or `_`, and `ext`
+  is one of `jpg`, `png`, or `txt`.
 
   Not supported for the JSON upload encoding.
 

--- a/src/github.com/matrix-org/rageshake/submit.go
+++ b/src/github.com/matrix-org/rageshake/submit.go
@@ -280,9 +280,13 @@ func parseFormPart(part *multipart.Part, p *payload, reportDir string) error {
 
 // we use a quite restrictive regexp for the filenames; in particular:
 //
-// * a limited set of extensions: we pick the mime-type when serving the file
-//   based on the extension, so allowing .js would be disasterous
+// * a limited set of extensions. We are careful to limit the content-types
+//   we will serve the files with, but somebody might accidentally point an
+//   Apache or nginx at the upload directory, which would serve js files as
+//   application/javascript and open XSS vulnerabilities.
+//
 // * no silly characters (/, ctrl chars, etc)
+//
 // * nothing starting with '.'
 var filenameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_-]+\.(jpg|png|txt)$`)
 


### PR DESCRIPTION
If a 'file' parameter is provided, save it as a file on disk. Also include a link to it from the github issue.