### PR TITLE
If a log is uploaded with a sensible filename, preserve it

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,16 @@ logs.)
 * `log`: a log file, with lines separated by newline characters. Multiple log
   files can be included by including several `log` parts.
 
+  If the log is uploaded with a filename `name.ext`, where `name` contains only
+  alphanumerics, `.`, `-` or `_`, and `ext` is one of `log` or `txt`, then the
+  file saved to disk is based on that. Otherwise, a suitable name is
+  constructed.
+
   If using the JSON upload encoding, the request object should instead include
   a single `logs` field, which is an array of objects with the following
   fields:
 
-    * `id`: textual identifier for the logs. Currently ignored.
+    * `id`: textual identifier for the logs. Used as the filename, as above.
     * `lines`: log data. Newlines should be  encoded as `\n`, as normal in JSON).
 
 * `compressed-log`: a gzipped logfile. Decompressed and then treated the same as

--- a/src/github.com/matrix-org/rageshake/submit_test.go
+++ b/src/github.com/matrix-org/rageshake/submit_test.go
@@ -112,7 +112,7 @@ func TestMultipartUpload(t *testing.T) {
 
 	// check logs uploaded correctly
 	checkUploadedFile(t, reportDir, "logs-0000.log.gz", true, "log\nlog\nlog")
-	checkUploadedFile(t, reportDir, "logs-0001.log.gz", true, "log")
+	checkUploadedFile(t, reportDir, "console.0.log.gz", true, "log")
 	checkUploadedFile(t, reportDir, "logs-0002.log.gz", true, "test\n")
 
 	// check file uploaded correctly
@@ -156,7 +156,7 @@ log
 log
 log
 ------WebKitFormBoundarySsdgl8Nq9voFyhdO
-Content-Disposition: form-data; name="log"; filename="instance-0.067644760733513781492004890379"
+Content-Disposition: form-data; name="log"; filename="console.0.log"
 Content-Type: text/plain
 
 log
@@ -207,7 +207,7 @@ func checkParsedMultipartUpload(t *testing.T, p *parsedPayload) {
 	if p.Logs[0] != wanted {
 		t.Errorf("Log 0: got %s, want %s", p.Logs[0], wanted)
 	}
-	wanted = "logs-0001.log.gz"
+	wanted = "console.0.log.gz"
 	if p.Logs[1] != wanted {
 		t.Errorf("Log 1: got %s, want %s", p.Logs[1], wanted)
 	}


### PR DESCRIPTION
the mobile guys want to be able to distinguish between crash.log and other logs.

Builds on https://github.com/matrix-org/rageshake/pull/17.