### PR TITLE
Add means to autocomplete issue references to a different repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Vector Creations Ltd
+Copyright 2017, 2020 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -48,7 +48,8 @@ type config struct {
 	// A GitHub personal access token, to create a GitHub issue for each report.
 	GithubToken string `yaml:"github_token"`
 
-	GithubProjectMappings map[string]string `yaml:"github_project_mappings"`
+	GithubProjectMappings       map[string]string `yaml:"github_project_mappings"`
+	AutocompleteProjectMappings map[string]string `yaml:"autocomplete_project_mappings"`
 
 	SlackWebhookURL string `yaml:"slack_webhook_url"`
 }
@@ -112,7 +113,7 @@ func main() {
 	}
 	log.Printf("Using %s/listing as public URI", apiPrefix)
 
-	http.Handle("/api/submit", &submitServer{ghClient, apiPrefix, cfg.GithubProjectMappings, slack})
+	http.Handle("/api/submit", &submitServer{ghClient, apiPrefix, cfg.GithubProjectMappings, cfg.AutocompleteProjectMappings, slack})
 
 	// Make sure bugs directory exists
 	_ = os.Mkdir("bugs", os.ModePerm)

--- a/main.go
+++ b/main.go
@@ -1,5 +1,6 @@
 /*
-Copyright 2017, 2020 Vector Creations Ltd
+Copyright 2017 Vector Creations Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -48,7 +49,10 @@ type config struct {
 	// A GitHub personal access token, to create a GitHub issue for each report.
 	GithubToken string `yaml:"github_token"`
 
-	GithubProjectMappings       map[string]string `yaml:"github_project_mappings"`
+	// Mappings from app name (as submitted in the API) to github repo for issue reporting.
+	GithubProjectMappings map[string]string `yaml:"github_project_mappings"`
+	// Mappings from app name (as submitted in the API) to github repo as to which the issues pertain.
+	// Not needed if the issues are reported to the main repo as github will complete the ambiguous references correctly.
 	AutocompleteProjectMappings map[string]string `yaml:"autocomplete_project_mappings"`
 
 	SlackWebhookURL string `yaml:"slack_webhook_url"`

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -17,6 +17,11 @@ github_token: secrettoken
 github_project_mappings:
    my-app: octocat/HelloWorld
 
+# mappings from app name (as submitted in the API) to github repo as to which the issues pertain.
+# not needed if the issues are reported to the main repo as github will complete the ambiguous references correctly.
+autocomplete_project_mappings:
+   my-app: octocat/HelloWorld_src
+
 # a Slack personal webhook URL (https://api.slack.com/incoming-webhooks), which
 # will be used to post a notification on Slack for each report.
 slack_webhook_url: https://hooks.slack.com/services/TTTTTTT/XXXXXXXXXX/YYYYYYYYYYY

--- a/submit.go
+++ b/submit.go
@@ -120,11 +120,13 @@ type submitResponse struct {
 	ReportURL string `json:"report_url,omitempty"`
 }
 
-// regex to catch and substitute ambiguous issue references with explicit ones to the actual repo they are in
-var ambiguousIssueRegex = regexp.MustCompile(`(^|[([{\s])(#\d+)([^\w]|$)`)
+// regex to match and substitute ambiguous issue references in the rageshake body text
+// matches a hash followed by digits optionally surrounded by whitespace or some punctuation
+// also matches if the input starts with digits where the hash becomes optional
+var ambiguousIssueRegex = regexp.MustCompile(`(^|[([{\s])(?:^|#)(\d+)([^\w]|$)`)
 
 func replaceAmbiguousIssueReferences(ownerRepo, text string) string {
-	t := ambiguousIssueRegex.ReplaceAllString(text, fmt.Sprintf("${1}%s$2$3", ownerRepo))
+	t := ambiguousIssueRegex.ReplaceAllString(text, fmt.Sprintf("${1}%s#$2$3", ownerRepo))
 	return t
 }
 

--- a/submit_test.go
+++ b/submit_test.go
@@ -492,6 +492,8 @@ func TestAutocompleteIssueReferences(t *testing.T) {
 		"test (#123) bar":     "test (owner/repo#123) bar",     // brackets
 		"Start #123. Now":     "Start owner/repo#123. Now",     // followed by punctuation
 		"#123foo":             "#123foo",                       // ignore
+		"foo/#123":            "foo/#123",                      // ignore
+		"123":                 "owner/repo#123",                // special case for entire body being a number
 	}
 
 	for text, expect := range tests {

--- a/submit_test.go
+++ b/submit_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 Vector Creations Ltd
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -479,6 +480,23 @@ user_id: id
 			continue
 		}
 		if got != expect {
+			t.Errorf("expected %s got %s", expect, got)
+		}
+	}
+}
+
+func TestAutocompleteIssueReferences(t *testing.T) {
+	tests := map[string]string{
+		"Testing #123 Foobar": "Testing owner/repo#123 Foobar", // standard
+		"#123":                "owner/repo#123",                // first/last word
+		"test (#123) bar":     "test (owner/repo#123) bar",     // brackets
+		"Start #123. Now":     "Start owner/repo#123. Now",     // followed by punctuation
+		"#123foo":             "#123foo",                       // ignore
+	}
+
+	for text, expect := range tests {
+		got := replaceAmbiguousIssueReferences("owner/repo", text)
+		if expect != got {
 			t.Errorf("expected %s got %s", expect, got)
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9242

Useful for setups where the bug report repo is not the src code repo and relative issue references refer to the bug report repo instead of the src code repo.