### PR TITLE
Docker will need the config file at toplevel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflag
 FROM scratch
 COPY --from=builder /build/rageshake /rageshake
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /build/rageshake.sample.yaml /rageshake.yaml
 WORKDIR /
 EXPOSE 9110
 CMD ["/rageshake"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflag
 FROM scratch
 COPY --from=builder /build/rageshake /rageshake
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /build/rageshake.sample.yaml /rageshake.yaml
+COPY --from=builder /build/rageshake.yaml /rageshake.yaml
 WORKDIR /
 EXPOSE 9110
 CMD ["/rageshake"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ go build
 Optional parameters:
 
  * `-config <path>`: The path to a YAML config file; see
-   [rageshake.sample.yaml](rageshake.sample.yaml) for more information.
+   [rageshake.sample.yaml](rageshake.sample.yaml) for more information. 
+   Customized file should be copied to rageshake.yaml.
  * `-listen <address>`: TCP network address to listen for HTTP requests
    on. Example: `:9110`.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Optional parameters:
 
  * `-config <path>`: The path to a YAML config file; see
    [rageshake.sample.yaml](rageshake.sample.yaml) for more information. 
-   Customized file should be copied to rageshake.yaml.
+   First copy rageshake.sample.yaml to rageshake.yaml, and then customize it with your values.
  * `-listen <address>`: TCP network address to listen for HTTP requests
    on. Example: `:9110`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  app:
+    entrypoint: ["/rageshake"]
+    image: rageshake:v1
+    container_name: bugreports
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:9110:9110


### PR DESCRIPTION
I was attempting with the docker build, docker-compose up -d and the container were continuously restarting. Checking the logs showed the entry point was restarting with "rageshake.yaml" not found. I just added the docker-compose file also, since I find that easier than remembering the commands.  