### PR TITLE
Add random string to report directories to prevent time-based collisions

### DIFF
--- a/changelog.d/39.bugfix
+++ b/changelog.d/39.bugfix
@@ -1,0 +1,1 @@
+Prevent timestamp collisions when reports are submitted within 1 second of each other.

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -146,6 +147,7 @@ func main() {
 	}
 	log.Printf("Using %s/listing as public URI", apiPrefix)
 
+	rand.Seed(time.Now().UnixNano())
 	http.Handle("/api/submit", &submitServer{ghClient, glClient, apiPrefix, slack, cfg})
 
 	// Make sure bugs directory exists

--- a/submit.go
+++ b/submit.go
@@ -20,11 +20,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base32"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -145,6 +147,9 @@ func (s *submitServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// files straight in
 	t := time.Now().UTC()
 	prefix := t.Format("2006-01-02/150405")
+	randBytes := make([]byte, 5)
+	rand.Read(randBytes)
+	prefix += "-" + base32.StdEncoding.EncodeToString(randBytes)
 	reportDir := filepath.Join("bugs", prefix)
 	if err := os.MkdirAll(reportDir, os.ModePerm); err != nil {
 		log.Println("Unable to create report directory", err)


### PR DESCRIPTION
Fixes a bug I ran into while testing matrix-org/matrix-react-sdk#7307, which causes receiving and sending clients to submit rageshakes near-simultaneously. If the timestamps collide, only one client's rageshake succeeds, and the other one fails with a 500.