### PR TITLE
Update go version to 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Web service which collects and serves bug reports.
 
-rageshake requires Go version 1.15 or later.
+rageshake requires Go version 1.16 or later.
 
 To run it, do:
 

--- a/changelog.d/42.misc
+++ b/changelog.d/42.misc
@@ -1,0 +1,1 @@
+Update docs that rageshakes requires golang >1.16.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matrix-org/rageshake
 
-go 1.15
+go 1.16
 
 require (
 	github.com/google/go-github v0.0.0-20170401000335-12363ffc1001


### PR DESCRIPTION
The linting scripts don't run on 1.15 any more, so builds are not
running against 1.15 any more.

Technically it will still compile and run against go 1.15 but if we
can't verify it in CI, it's not known to be true in future.