### PR TITLE
Build and push multi-arch Docker images on ghcr.io

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,6 +17,9 @@ jobs:
       contents: read
 
     steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -25,11 +28,27 @@ jobs:
           bake-target: docker-metadata-action
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+
+      - name: Docker meta (debug variant)
+        id: meta-debug
+        uses: docker/metadata-action@v3
+        with:
+          images: "${{ env.IMAGE }}"
+          bake-target: docker-metadata-action-debug
+          tags: |
+            type=ref,event=branch,suffix=-debug
+            type=semver,pattern={{version}},suffix=-debug
+            type=semver,pattern={{major}}.{{minor}},suffix=-debug
+            type=semver,pattern={{major}},suffix=-debug
+            type=sha,suffix=-debug
+
+      - name: Merge buildx bake files
+        run: |
+            jq -s '.[0] * .[1]' ${{ steps.meta.outputs.bake-file }} ${{ steps.meta-debug.outputs.bake-file }} > docker-bake.override.json
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -46,28 +65,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # For pull-requests, only read from the cache, do not try to push to the
+      # cache or the image itself
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/bake-action@v1
         if: github.event_name == 'pull_request'
         with:
-          platforms: |
-            linux/amd64
-            linux/arm64
-            linux/arm
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          set: |
+            base.cache-from=type=registry,ref=${{ env.IMAGE }}:buildcache
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/bake-action@v1
         if: github.event_name != 'pull_request'
         with:
-          platforms: |
-            linux/amd64
-            linux/arm64
-            linux/arm
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
+          set: |
+            base.output=type=image,push=true
+            base.cache-from=type=registry,ref=${{ env.IMAGE }}:buildcache
+            base.cache-to=type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,73 @@
+name: Docker
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: "${{ env.IMAGE }}"
+          bake-target: docker-metadata-action
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'pull_request'
+        with:
+          platforms: |
+            linux/amd64
+            linux/arm64
+            linux/arm
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          platforms: |
+            linux/amd64
+            linux/arm64
+            linux/arm
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o rageshake
 ## Runtime stage, debug variant ##
 FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static-debian${DEBIAN_VERSION}:debug-nonroot AS debug
 COPY --from=builder /build/rageshake /rageshake
+WORKDIR /
 EXPOSE 9110
 ENTRYPOINT ["/rageshake"]
 
 ## Runtime stage ##
 FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static-debian${DEBIAN_VERSION}:nonroot
 COPY --from=builder /build/rageshake /rageshake
+WORKDIR /
 EXPOSE 9110
 ENTRYPOINT ["/rageshake"]

--- a/changelog.d/47.misc
+++ b/changelog.d/47.misc
@@ -1,0 +1,1 @@
+Build and push a multi-arch Docker image on the GitHub Container Registry.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,25 @@
+// This is what is baked by GitHub Actions
+group "default" { targets = ["regular", "debug"] }
+
+// Targets filled by GitHub Actions: one for the regular tag, one for the debug tag
+target "docker-metadata-action" {}
+target "docker-metadata-action-debug" {}
+
+// This sets the platforms and is further extended by GitHub Actions to set the
+// output and the cache locations
+target "base" {
+  platforms = [
+    "linux/amd64",
+    "linux/arm64",
+    "linux/arm",
+  ]
+}
+
+target "regular" {
+  inherits = ["base", "docker-metadata-action"]
+}
+
+target "debug" {
+  inherits = ["base", "docker-metadata-action-debug"]
+  target = "debug"
+}


### PR DESCRIPTION
This does two things:
 - enhance the Dockerfile to be multi-arch capable (also allows it to run as non-root)
 - build and push a Docker image on ghcr.io/matrix-org/rageshake via GitHub Actions

There are a few important things to note about the changes in the Dockerfile:
 - the runtime image is based on an image [from the distroless project](https://github.com/GoogleContainerTools/distroless)
 - this allows for the container to run as non-root (there is a `/etc/passwd` entry for that)
 - the image can be cross-compiled (e.g. building the amd64 image from an arm64 host and vice-versa) with no qemu emulation involved. This however requires a buildkit-enabled Docker (which is the default on Docker Desktop), e.g. `export DOCKER_BUILDKIT=1` on Linux
 - I tested the image both on my M1 MacBook (arm64) and my x86_64 desktop
 - I switched the `/rageshake` binary to be the entrypoint instead of the command. This allows to run the image like `docker run ghcr.io/matrix-org/rageshake -help` instead of `docker run ghcr.io/matrix-org/rageshake /rageshake -help`