### PR TITLE
Initial attempt at a generic webhook for reports.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,0 @@
-docker: 
-	DOCKER_BUILDKIT=1 docker build -t rageshake:latest .
-	docker run --rm --name rageshake --network rageshake-search --mount type=bind,source=$(shell pwd)/bugs,target=/bugs --mount type=bind,source=$(shell pwd)/rageshake.yaml,target=/rageshake.yaml -p 127.0.0.1:9110:9110 rageshake:latest -listen :9110
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+docker: 
+	DOCKER_BUILDKIT=1 docker build -t rageshake:latest .
+	docker run --rm --name rageshake --network rageshake-search --mount type=bind,source=$(shell pwd)/bugs,target=/bugs --mount type=bind,source=$(shell pwd)/rageshake.yaml,target=/rageshake.yaml -p 127.0.0.1:9110:9110 rageshake:latest -listen :9110
+

--- a/README.md
+++ b/README.md
@@ -105,3 +105,13 @@ You can get notifications when a new rageshake arrives on the server.
 Currently this tool supports pushing notifications as GitHub issues in a repo,
 through a Slack webhook or by email, cf sample config file for how to
 configure them.
+
+### Generic Webhook Notifications
+
+You can receive a webhook notifications when a new rageshake arrives on the server.
+
+These requests contain all the parsed metadata, and links to the uploaded files, and any github/gitlab
+issues created.
+
+Details on the request and expected response are [available](docs/generic\_webhook.md).
+

--- a/changelog.d/50.feature
+++ b/changelog.d/50.feature
@@ -1,0 +1,1 @@
+Allow forwarding of a request to a webhook endpoint.

--- a/docs/generic_webhook.md
+++ b/docs/generic_webhook.md
@@ -1,0 +1,38 @@
+## Generic webhook request
+
+If the configuration option `generic_webhook_url` is set, then a synchronous request to
+the endpoint will be sent after the incoming request is parsed and the files are uploaded.
+
+The webhook is designed for notification or other tracking services, and does not contain
+the original log files uploaded.
+
+(If you want the original log files, we suggest to implement the rageshake interface itself).
+
+A sample JSON body is as follows:
+
+```
+{
+  'user_text': 'test\r\n\r\nIssue: No issue link given',
+  'app': 'element-web',
+  'data': {
+    'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0',
+    'Version': '0f15ba34cdf5-react-0f15ba34cdf5-js-0f15ba34cdf5',
+    ...
+    'user_id': '@michaelgoesforawalk:matrix.org'},
+  'labels': None,
+  'logs': [
+    'logs-0000.log.gz',
+    'logs-0001.log.gz',
+    'logs-0002.log.gz',
+  ],
+  'logErrors': None,
+  'files': [
+    'screenshot.png'
+  ],
+  'fileErrors': None,
+  'report_url': 'https://github.com/your-org/your-repo/issues/1251',
+  'listing_url': 'http://your-rageshake-server/api/listing/2022-01-25/154742-OOXBVGIX'
+}
+```
+
+The log and other files can be individually downloaded by concatenating the `listing_url` and the `logs` or `files` name.

--- a/docs/generic_webhook.md
+++ b/docs/generic_webhook.md
@@ -1,7 +1,8 @@
 ## Generic webhook request
 
-If the configuration option `generic_webhook_url` is set, then a synchronous request to
-the endpoint will be sent after the incoming request is parsed and the files are uploaded.
+If the configuration option `generic_webhook_urls` is set, then an asynchronous request to
+each endpoint listed will be sent in parallel, after the incoming request is parsed and the
+files are uploaded.
 
 The webhook is designed for notification or other tracking services, and does not contain
 the original log files uploaded.
@@ -36,3 +37,4 @@ A sample JSON body is as follows:
 ```
 
 The log and other files can be individually downloaded by concatenating the `listing_url` and the `logs` or `files` name.
+You may need to provide a HTTP basic auth user/pass if configured on your rageshake server.

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ type config struct {
 
 	SMTPPassword string `yaml:"smtp_password"`
 
-	GenericWebhookURL string `yaml:"generic_webhook_url"`
+	GenericWebhookURLs []string `yaml:"generic_webhook_urls"`
 }
 
 func basicAuth(handler http.Handler, username, password, realm string) http.Handler {
@@ -181,11 +181,11 @@ func main() {
 }
 
 func configureGenericWebhookClient(cfg *config) (*http.Client) {
-	if cfg.GenericWebhookURL == "" {
-		fmt.Println("No generic_webhook_url configured.")
+	if len(cfg.GenericWebhookURLs) == 0 {
+		fmt.Println("No generic_webhook_urls configured.")
 		return nil
 	}
-	fmt.Println("Will forward metadata of all requests to ", cfg.GenericWebhookURL)
+	fmt.Println("Will forward metadata of all requests to ", cfg.GenericWebhookURLs)
 	return &http.Client{
 		Timeout: time.Second * 300,
 	}

--- a/main.go
+++ b/main.go
@@ -135,15 +135,8 @@ func main() {
 	if len(cfg.EmailAddresses) > 0 && cfg.SMTPServer == "" {
 		log.Fatal("Email address(es) specified but no smtp_server configured. Wrong configuration, aborting...")
 	}
-	var genericWebhookClient *http.Client
-	if cfg.GenericWebhookURL == "" {
-		fmt.Println("No generic_webhook_url configured.")
-	} else {
-		fmt.Println("Will forward metadata of all requests to ", cfg.GenericWebhookURL)
-		genericWebhookClient = &http.Client{
-			Timeout: time.Second * 300,
-		}
-	}
+
+	genericWebhookClient := configureGenericWebhookClient(cfg)
 
 	apiPrefix := cfg.APIPrefix
 	if apiPrefix == "" {
@@ -185,6 +178,17 @@ func main() {
 	log.Println("Listening on", *bindAddr)
 
 	log.Fatal(http.ListenAndServe(*bindAddr, nil))
+}
+
+func configureGenericWebhookClient(cfg *config) (*http.Client) {
+	if cfg.GenericWebhookURL == "" {
+		fmt.Println("No generic_webhook_url configured.")
+		return nil
+	}
+	fmt.Println("Will forward metadata of all requests to ", cfg.GenericWebhookURL)
+	return &http.Client{
+		Timeout: time.Second * 300,
+	}
 }
 
 func loadConfig(configPath string) (*config, error) {

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -50,3 +50,9 @@ email_from: Rageshake <rageshake@matrix.org>
 smtp_server: localhost:25
 smtp_username: myemailuser
 smtp_password: myemailpass
+
+
+# a list of webhook URLs, (see docs/generic_webhook.md)
+generic_webhook_urls: 
+  - https://server.example.com/your-server/api
+  - http://another-server.com/api

--- a/submit.go
+++ b/submit.go
@@ -521,24 +521,26 @@ func (s *submitServer) submitGenericWebhook(p parsedPayload, listingURL string, 
 	if s.genericWebhookClient == nil {
 		return nil
 	}
-	url := s.cfg.GenericWebhookURL
-	log.Println("Submitting json to URL", url)
-	// Enrich the parsedPayload with a reportURL and listingURL, to convert a single struct
-	// to JSON easily
-	genericHookPayload := genericWebhookPayload{
-		parsedPayload: p,
-		ReportURL: reportURL,
-		ListingURL: listingURL,
-	}
+	for _, url := range s.cfg.GenericWebhookURLs {
+		// Enrich the parsedPayload with a reportURL and listingURL, to convert a single struct
+		// to JSON easily
+		genericHookPayload := genericWebhookPayload{
+			parsedPayload: p,
+			ReportURL: reportURL,
+			ListingURL: listingURL,
+		}
 
-	payloadBuffer := new(bytes.Buffer)
-	json.NewEncoder(payloadBuffer).Encode(genericHookPayload)
-	req, err := http.NewRequest("POST", url, payloadBuffer)
-	req.Header.Set("Content-Type", "application/json")
-	if err != nil {
-		return err
+		payloadBuffer := new(bytes.Buffer)
+		json.NewEncoder(payloadBuffer).Encode(genericHookPayload)
+		req, err := http.NewRequest("POST", url, payloadBuffer)
+		req.Header.Set("Content-Type", "application/json")
+		if err != nil {
+			log.Println("Unable to submit to URL ", url, " ", err)
+			return err
+		}
+		log.Println("Making generic webhook request to URL ", url)
+		go s.sendGenericWebhook(req)
 	}
-	go s.sendGenericWebhook(req)
 	return nil
 }
 

--- a/submit.go
+++ b/submit.go
@@ -521,14 +521,14 @@ func (s *submitServer) submitGenericWebhook(p parsedPayload, listingURL string, 
 	if s.genericWebhookClient == nil {
 		return nil
 	}
+	genericHookPayload := genericWebhookPayload{
+		parsedPayload: p,
+		ReportURL: reportURL,
+		ListingURL: listingURL,
+	}
 	for _, url := range s.cfg.GenericWebhookURLs {
 		// Enrich the parsedPayload with a reportURL and listingURL, to convert a single struct
 		// to JSON easily
-		genericHookPayload := genericWebhookPayload{
-			parsedPayload: p,
-			ReportURL: reportURL,
-			ListingURL: listingURL,
-		}
 
 		payloadBuffer := new(bytes.Buffer)
 		json.NewEncoder(payloadBuffer).Encode(genericHookPayload)


### PR DESCRIPTION
Background submission to a notification server that doesn't block rageshake submission.

Timeout requests after 300s (to provide some wiggle room for servers that choose to take action inline)

Add docs on the format of the endpoint (though much of it is pass-through so there is no fixed schema in most cases)