### PR TITLE
Allow upload of files with a .json postfix.

### DIFF
--- a/changelog.d/52.feature
+++ b/changelog.d/52.feature
@@ -1,0 +1,1 @@
+Allow upload of Files with a .json postfix.

--- a/logserver.go
+++ b/logserver.go
@@ -119,6 +119,9 @@ func extensionToMimeType(path string) string {
 		return "image/jpeg"
 	}
 
+	if strings.HasSuffix(path, ".json") {
+		return "application/json"
+	}
 	return "application/octet-stream"
 }
 

--- a/submit.go
+++ b/submit.go
@@ -402,7 +402,7 @@ func formPartToPayload(field, data string, p *parsedPayload) {
 // * no silly characters (/, ctrl chars, etc)
 //
 // * nothing starting with '.'
-var filenameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_-]+\.(jpg|png|txt)$`)
+var filenameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_-]+\.(jpg|png|txt|json)$`)
 
 // saveFormPart saves a file upload to the report directory.
 //


### PR DESCRIPTION
The limit was there to make arbitrary file download hard, json files are mostly treated the same as text files so this should be fine.