### PR TITLE
Serve a tarball containing the contents of a given directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Serves submitted bug reports. Protected by basic HTTP auth using the
 username/password provided in the environment. A browsable list, collated by
 report submission date and time.
 
+A whole directory can be downloaded as a tarball by appending the parameter `?format=tar.gz` to the end of the URL path
+
 ### POST `/api/submit`
 
 Submission endpoint: this is where applications should send their reports.

--- a/changelog.d/53.feature
+++ b/changelog.d/53.feature
@@ -1,0 +1,1 @@
+Provide ?format=tar.gz option on directory listings to download tarball.

--- a/logserver.go
+++ b/logserver.go
@@ -84,6 +84,7 @@ func serveFile(w http.ResponseWriter, r *http.Request, path string) {
 	// if it's a directory, serve a listing or a tarball
 	if d.IsDir() {
 		serveDirectory(w, r, path)
+		return
 	}
 
 	// if it's a gzipped log file, serve it as text
@@ -140,7 +141,6 @@ func serveDirectory(w http.ResponseWriter, r *http.Request, path string) {
 	}
 	log.Println("Serving directory listing of", path)
 	http.ServeFile(w, r, path)
-	return
 }
 
 // Streams a dynamically created tar.gz file with the contents of the given directory

--- a/logserver.go
+++ b/logserver.go
@@ -155,7 +155,7 @@ func serveTarball(w http.ResponseWriter, r *http.Request, dir string) error {
 	// This tends to trigger archive type tools, which will then use the filename to 
 	// identify the contents correctly.
 	w.Header().Set("Content-Type", "application/gzip")
-	w.Header().Set("Content-Disposition", "attachment; filename=" + dfilename+".tar.gz")
+	w.Header().Set("Content-Disposition", "attachment; filename=" + dfilename + ".tar.gz")
 
 	filenames, err := directory.Readdirnames(-1)
 	if err != nil {

--- a/logserver.go
+++ b/logserver.go
@@ -291,5 +291,3 @@ func containsDotDot(v string) bool {
 	return false
 }
 func isSlashRune(r rune) bool { return r == '/' || r == '\\' }
-
-

--- a/logserver.go
+++ b/logserver.go
@@ -149,7 +149,7 @@ func serveTarball(w http.ResponseWriter, r *http.Request, dir string) error {
 	}
 	// "disposition filename"
 	dfilename := strings.Trim(r.URL.Path,"/")
-	dfilename = strings.Replace(dfile, "/","_",-1)
+	dfilename = strings.Replace(dfilename, "/","_",-1)
 
 	// There is no application/tgz or similar; return a gzip file as best option. 
 	// This tends to trigger archive type tools, which will then use the filename to 


### PR DESCRIPTION
This will make it easier to get all logs for a given bug; preventing users
needing to run scripts to download all files.

 - we cannot make the link exist in the directory listing as there are scripts
   that automate downloads which would pick this up.

 - Unsure if "?format=tar.gz" is the right option to enable this; I couldn't think
   of something easy to do but hard to not get picked up by existing automation, and
   wouldn't conflict with existing filenames. Suggestions welcome.