### PR TITLE
Persist prefix as a unique id in rageshakes

### DIFF
--- a/changelog.d/54.feature
+++ b/changelog.d/54.feature
@@ -1,0 +1,1 @@
+Pass the prefix as a unique ID for the rageshake to the generic webhook mechanism.

--- a/logserver.go
+++ b/logserver.go
@@ -69,7 +69,6 @@ func (f *logServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	serveFile(w, r, upath)
 }
 
-
 func serveFile(w http.ResponseWriter, r *http.Request, path string) {
 	d, err := os.Stat(path)
 	if err != nil {
@@ -144,9 +143,9 @@ func serveDirectory(w http.ResponseWriter, r *http.Request, path string) {
 }
 
 // Streams a dynamically created tar.gz file with the contents of the given directory
-// Will serve a partial, corrupted response if there is a error partway through the 
+// Will serve a partial, corrupted response if there is a error partway through the
 // operation as we stream the response.
-// 
+//
 // The resultant tarball will contain a single directory containing all the files
 // so it can unpack cleanly without overwriting other files.
 //
@@ -163,14 +162,14 @@ func serveTarball(w http.ResponseWriter, r *http.Request, dir string) error {
 	// and removes leading and trailing `/` and replaces internal `/` with `_`
 	// to form a suitable filename for use in the content-disposition header
 	// dfilename would turn into `2022-01-10_184843-BZZXEGYH`
-	dfilename := strings.Trim(r.URL.Path,"/")
-	dfilename = strings.Replace(dfilename, "/","_",-1)
+	dfilename := strings.Trim(r.URL.Path, "/")
+	dfilename = strings.Replace(dfilename, "/", "_", -1)
 
-	// There is no application/tgz or similar; return a gzip file as best option. 
-	// This tends to trigger archive type tools, which will then use the filename to 
+	// There is no application/tgz or similar; return a gzip file as best option.
+	// This tends to trigger archive type tools, which will then use the filename to
 	// identify the contents correctly.
 	w.Header().Set("Content-Type", "application/gzip")
-	w.Header().Set("Content-Disposition", "attachment; filename=" + dfilename + ".tar.gz")
+	w.Header().Set("Content-Disposition", "attachment; filename="+dfilename+".tar.gz")
 
 	files, err := directory.Readdir(-1)
 	if err != nil {
@@ -181,7 +180,6 @@ func serveTarball(w http.ResponseWriter, r *http.Request, dir string) error {
 	defer gzip.Close()
 	targz := tar.NewWriter(gzip)
 	defer targz.Close()
-
 
 	for _, file := range files {
 		if file.IsDir() {
@@ -206,7 +204,7 @@ func serveTarball(w http.ResponseWriter, r *http.Request, dir string) error {
 	return nil
 }
 
-// Add a single file into the archive. 
+// Add a single file into the archive.
 func addToArchive(targz *tar.Writer, dfilename string, filename string) error {
 	file, err := os.Open(filename)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 	log.Fatal(http.ListenAndServe(*bindAddr, nil))
 }
 
-func configureGenericWebhookClient(cfg *config) (*http.Client) {
+func configureGenericWebhookClient(cfg *config) *http.Client {
 	if len(cfg.GenericWebhookURLs) == 0 {
 		fmt.Println("No generic_webhook_urls configured.")
 		return nil

--- a/submit.go
+++ b/submit.go
@@ -58,7 +58,7 @@ type submitServer struct {
 	slack *slackClient
 
 	genericWebhookClient *http.Client
-	cfg *config
+	cfg                  *config
 }
 
 // the type of payload which can be uploaded as JSON to the submit endpoint
@@ -77,11 +77,10 @@ type jsonLogEntry struct {
 	Lines string `json:"lines"`
 }
 
-
 type genericWebhookPayload struct {
 	parsedPayload
-	ReportURL string             `json:"report_url"`
-	ListingURL string            `json:"listing_url"`
+	ReportURL  string `json:"report_url"`
+	ListingURL string `json:"listing_url"`
 }
 
 // the payload after parsing
@@ -509,7 +508,7 @@ func (s *submitServer) saveReport(ctx context.Context, p parsedPayload, reportDi
 
 // submitGenericWebhook submits a basic JSON body to an endpoint configured in the config
 //
-// The request does not include the log body, only the metadata in the parsedPayload, 
+// The request does not include the log body, only the metadata in the parsedPayload,
 // with the required listingURL to obtain the logs over http if required.
 //
 // If a github or gitlab issue was previously made, the reportURL will also be passed.
@@ -523,8 +522,8 @@ func (s *submitServer) submitGenericWebhook(p parsedPayload, listingURL string, 
 	}
 	genericHookPayload := genericWebhookPayload{
 		parsedPayload: p,
-		ReportURL: reportURL,
-		ListingURL: listingURL,
+		ReportURL:     reportURL,
+		ListingURL:    listingURL,
 	}
 	for _, url := range s.cfg.GenericWebhookURLs {
 		// Enrich the parsedPayload with a reportURL and listingURL, to convert a single struct
@@ -553,7 +552,6 @@ func (s *submitServer) sendGenericWebhook(req *http.Request) {
 		log.Println("Got response", resp.Status)
 	}
 }
-
 
 func (s *submitServer) submitGithubIssue(ctx context.Context, p parsedPayload, listingURL string, resp *submitResponse) error {
 	if s.ghClient == nil {

--- a/submit.go
+++ b/submit.go
@@ -85,6 +85,7 @@ type genericWebhookPayload struct {
 
 // the payload after parsing
 type parsedPayload struct {
+	ID         string            `json:"id"`
 	UserText   string            `json:"user_text"`
 	AppName    string            `json:"app"`
 	Data       map[string]string `json:"data"`
@@ -177,6 +178,11 @@ func (s *submitServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		return
 	}
+
+	// We use this prefix (eg, 2022-05-01/125223-abcde) as a unique identifier for this rageshake.
+	// This is going to be used to uniquely identify rageshakes, even if they are not submitted to
+	// an issue tracker for instance with automatic rageshakes that can be plentiful
+	p.ID = prefix
 
 	resp, err := s.saveReport(req.Context(), *p, reportDir, listingURL)
 	if err != nil {

--- a/submit.go
+++ b/submit.go
@@ -77,23 +77,24 @@ type jsonLogEntry struct {
 	Lines string `json:"lines"`
 }
 
+// Stores additional information created during processing of a payload
 type genericWebhookPayload struct {
 	payload
-	ReportURL  string `json:"report_url"`
-	ListingURL string `json:"listing_url"`
+	ReportURL  string `json:"report_url"` // If a github/gitlab report is generated, this is set.
+	ListingURL string `json:"listing_url"` // Complete link to the listing URL that contains all uploaded logs
 }
 
-// the payload after parsing
+// Stores information about a request made to this server
 type payload struct {
-	ID         string            `json:"id"`
-	UserText   string            `json:"user_text"`
-	AppName    string            `json:"app"`
-	Data       map[string]string `json:"data"`
-	Labels     []string          `json:"labels"`
-	Logs       []string          `json:"logs"`
-	LogErrors  []string          `json:"logErrors"`
-	Files      []string          `json:"files"`
-	FileErrors []string          `json:"fileErrors"`
+	ID         string            `json:"id"` // A unique ID for this payload, generated within this server 
+	UserText   string            `json:"user_text"` // A multi-line string containing the user description of the fault. 
+	AppName    string            `json:"app"` // A short slug to identify the app making the report
+	Data       map[string]string `json:"data"` // Arbitrary data to annotate the report
+	Labels     []string          `json:"labels"` // Short labels to group reports
+	Logs       []string          `json:"logs"` // A list of names of logs recognised by the server
+	LogErrors  []string          `json:"logErrors"` // Set if there are log parsing errors
+	Files      []string          `json:"files"` // A list of other files (not logs) uploaded as part of the rageshake
+	FileErrors []string          `json:"fileErrors"` // Set if there are file parsing errors
 }
 
 func (p payload) WriteTo(out io.Writer) {

--- a/submit.go
+++ b/submit.go
@@ -80,21 +80,32 @@ type jsonLogEntry struct {
 // Stores additional information created during processing of a payload
 type genericWebhookPayload struct {
 	payload
-	ReportURL  string `json:"report_url"` // If a github/gitlab report is generated, this is set.
-	ListingURL string `json:"listing_url"` // Complete link to the listing URL that contains all uploaded logs
+	// If a github/gitlab report is generated, this is set.
+	ReportURL  string `json:"report_url"`
+	// Complete link to the listing URL that contains all uploaded logs
+	ListingURL string `json:"listing_url"`
 }
 
 // Stores information about a request made to this server
 type payload struct {
-	ID         string            `json:"id"` // A unique ID for this payload, generated within this server 
-	UserText   string            `json:"user_text"` // A multi-line string containing the user description of the fault. 
-	AppName    string            `json:"app"` // A short slug to identify the app making the report
-	Data       map[string]string `json:"data"` // Arbitrary data to annotate the report
-	Labels     []string          `json:"labels"` // Short labels to group reports
-	Logs       []string          `json:"logs"` // A list of names of logs recognised by the server
-	LogErrors  []string          `json:"logErrors"` // Set if there are log parsing errors
-	Files      []string          `json:"files"` // A list of other files (not logs) uploaded as part of the rageshake
-	FileErrors []string          `json:"fileErrors"` // Set if there are file parsing errors
+	// A unique ID for this payload, generated within this server 
+	ID         string            `json:"id"`
+	// A multi-line string containing the user description of the fault. 
+	UserText   string            `json:"user_text"`
+	// A short slug to identify the app making the report
+	AppName    string            `json:"app"`
+	// Arbitrary data to annotate the report
+	Data       map[string]string `json:"data"`
+	// Short labels to group reports
+	Labels     []string          `json:"labels"`
+	// A list of names of logs recognised by the server
+	Logs       []string          `json:"logs"`
+	// Set if there are log parsing errors
+	LogErrors  []string          `json:"logErrors"`
+	// A list of other files (not logs) uploaded as part of the rageshake
+	Files      []string          `json:"files"`
+	// Set if there are file parsing errors
+	FileErrors []string          `json:"fileErrors"`
 }
 
 func (p payload) WriteTo(out io.Writer) {

--- a/submit_test.go
+++ b/submit_test.go
@@ -35,7 +35,7 @@ import (
 //
 // if tempDir is empty, a new temp dir is created, and deleted when the test
 // completes.
-func testParsePayload(t *testing.T, body, contentType string, tempDir string) (*parsedPayload, *http.Response) {
+func testParsePayload(t *testing.T, body, contentType string, tempDir string) (*payload, *http.Response) {
 	req, err := http.NewRequest("POST", "/api/submit", strings.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
@@ -232,7 +232,7 @@ Content-Type: application/octet-stream
 	return
 }
 
-func checkParsedMultipartUpload(t *testing.T, p *parsedPayload) {
+func checkParsedMultipartUpload(t *testing.T, p *payload) {
 	wanted := "test words."
 	if p.UserText != wanted {
 		t.Errorf("User text: got %s, want %s", p.UserText, wanted)
@@ -478,7 +478,7 @@ user_id: id
 	}
 	var buf bytes.Buffer
 	for _, v := range sample {
-		p := parsedPayload{Data: v.data}
+		p := payload{Data: v.data}
 		buf.Reset()
 		p.WriteTo(&buf)
 		got := strings.TrimSpace(buf.String())
@@ -488,7 +488,7 @@ user_id: id
 	}
 
 	for k, v := range sample {
-		p := parsedPayload{Data: v.data}
+		p := payload{Data: v.data}
 		res := buildGithubIssueRequest(p, "")
 		got := *res.Body
 		if k == 0 {


### PR DESCRIPTION
Rageshakes are too numerous for just uploading to github any more.

The generic webhook (and other) mechanism are able to track a greater volume of requests than simply uploading to github; however this means that we are going to be unable to use the issue ID generated by the github upload to track the rageshake.

We do create a unique ID for the on-disk rageshake, we expose this prefix as an ID in the objects we send onwards via the generic webhook API, which can then be used in external systems to uniquely identify this rageshake.

Technically this isn't any information that isn't in the ListingURL already, but i feel having a separate parameter storing the unique ID (such that it can evolve separately from the listingURL) is the right way to go.