### PR TITLE
Create additional labels when detecting Dendrite or Conduit homeserver

### DIFF
--- a/changelog.d/55.feature
+++ b/changelog.d/55.feature
@@ -1,0 +1,1 @@
+Add Dendrite and Conduit labels when detected in the `server_version` field of the rageshake payload


### PR DESCRIPTION
This should make it easier to spot rageshakes related to users running these homeservers. Currently the `server_version` field is only sent by Element Android though so will need to do something about iOS still.

Some of the formatting is due to running `goimports` on `submit.go` so sorry about the noise with that.