### PR TITLE
Block applications not listed in an allow list.

### DIFF
--- a/changelog.d/67.feature
+++ b/changelog.d/67.feature
@@ -1,0 +1,1 @@
+Add config option to block unknown appplication names.

--- a/docs/blocked_rageshake.md
+++ b/docs/blocked_rageshake.md
@@ -27,7 +27,7 @@ There is generally a configuration file in your application that you can alter t
 
 The easiest solution to this error is to stop sending rageshakes entirely, which may require a code or configuration change in your client.
 
-However, if you wish to accept bug reports from your users applications; you will need to run your own copy of this rageshake server and update the URL appropriately.
+However, if you wish to accept bug reports from your users applications, you will need to run your own copy of this rageshake server and update the URL appropriately.
 
 ## Application specific config locations:
  * element-web: `bug_report_endpoint_url` in the [sample configuration for element web](https://github.com/vector-im/element-web/blob/develop/config.sample.json).

--- a/docs/blocked_rageshake.md
+++ b/docs/blocked_rageshake.md
@@ -1,0 +1,35 @@
+# Rageshake server not accepting rageshakes
+
+This page contains information useful to someone who has had their rageshake rejected by a rageshake server.
+
+We include it within the error messages to provide a place with context for users reading the error message and wanting
+to know more.
+
+## For matrix client users
+
+Thank you for attempting to report a bug with your matrix client; unfortunately your client application is likely incorrectly configured.
+
+The rageshake server you attempted to upload a report to is not accepting rageshakes from your client at this time.
+
+Generally, the developers who run a rageshake server will only be able to handle reports for applications they are developing,
+and your application is not listed as one of those applications.
+
+Please contact the distributor of your application or the administrator of the web site you visit to report this as a problem.
+
+## For developers of matrix clients
+
+Your application is likely based on one of the matrix SDKs or element applications, if it is submitting rageshakes to a rageshake server.
+
+A change has been made to pre-filter reports that the developers using this rageshake server for applications they do not have control over.
+Typically reports from unknown applications would have to be manually triaged and discarded; there is now automatic filtering in place, which reduces overall effort.
+
+There is generally a configuration file in your application that you can alter to change where these reports are sent, which may require rebuilding and releasing the client.
+
+The easiest solution to this error is to stop sending rageshakes entirely, which may require a code or configuration change in your client.
+
+However, if you wish to accept bug reports from your users applications; you will need to run your own copy of this rageshake server and update the URL appropriately.
+
+## Application specific config locations:
+ * element-web: `bug_report_endpoint_url` in the [sample configuration for element web](https://github.com/vector-im/element-web/blob/develop/config.sample.json).
+ * element-ios: `bugReportEndpointUrlString` in the [BuildSettings.swift](https://github.com/vector-im/element-ios/blob/develop/Config/BuildSettings.swift)
+ * element-android: `bug_report_url` in the [config.xml file for the build](https://github.com/vector-im/element-android/blob/develop/vector-config/src/main/res/values/config.xml)

--- a/main.go
+++ b/main.go
@@ -48,6 +48,10 @@ type config struct {
 	// External URI to /api
 	APIPrefix string `yaml:"api_prefix"`
 
+	// Allowed rageshake app names
+	AllowedAppNames   []string `yaml:"allowed_app_names"`
+	AllowedAppNameMap map[string]bool
+
 	// A GitHub personal access token, to create a GitHub issue for each report.
 	GithubToken string `yaml:"github_token"`
 
@@ -100,6 +104,16 @@ func main() {
 	}
 
 	var ghClient *github.Client
+
+	if len(cfg.AllowedAppNames) == 0 {
+		fmt.Println("Warning: allowed_app_names is empty. Accepting requests from all app names")
+	} else {
+		// Convert list up to a map to make lookups easier
+		cfg.AllowedAppNameMap = make(map[string]bool)
+		for _, app := range cfg.AllowedAppNames {
+			cfg.AllowedAppNameMap[app] = true
+		}
+	}
 
 	if cfg.GithubToken == "" {
 		fmt.Println("No github_token configured. Reporting bugs to github is disabled.")

--- a/main.go
+++ b/main.go
@@ -196,6 +196,7 @@ func configureAppNameMap(cfg *config) map[string]bool {
 	}
 	return allowedAppNameMap
 }
+
 func configureGenericWebhookClient(cfg *config) *http.Client {
 	if len(cfg.GenericWebhookURLs) == 0 {
 		fmt.Println("No generic_webhook_urls configured.")

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ type config struct {
 
 	// Allowed rageshake app names
 	AllowedAppNames   []string `yaml:"allowed_app_names"`
-	AllowedAppNameMap map[string]bool
+	allowedAppNameMap map[string]bool
 
 	// A GitHub personal access token, to create a GitHub issue for each report.
 	GithubToken string `yaml:"github_token"`
@@ -109,9 +109,9 @@ func main() {
 		fmt.Println("Warning: allowed_app_names is empty. Accepting requests from all app names")
 	} else {
 		// Convert list up to a map to make lookups easier
-		cfg.AllowedAppNameMap = make(map[string]bool)
+		cfg.allowedAppNameMap = make(map[string]bool)
 		for _, app := range cfg.AllowedAppNames {
-			cfg.AllowedAppNameMap[app] = true
+			cfg.allowedAppNameMap[app] = true
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -105,16 +105,6 @@ func main() {
 
 	var ghClient *github.Client
 
-	if len(cfg.AllowedAppNames) == 0 {
-		fmt.Println("Warning: allowed_app_names is empty. Accepting requests from all app names")
-	} else {
-		// Convert list up to a map to make lookups easier
-		cfg.allowedAppNameMap = make(map[string]bool)
-		for _, app := range cfg.AllowedAppNames {
-			cfg.allowedAppNameMap[app] = true
-		}
-	}
-
 	if cfg.GithubToken == "" {
 		fmt.Println("No github_token configured. Reporting bugs to github is disabled.")
 	} else {
@@ -214,5 +204,16 @@ func loadConfig(configPath string) (*config, error) {
 	if err = yaml.Unmarshal(contents, &cfg); err != nil {
 		return nil, err
 	}
+
+	if len(cfg.AllowedAppNames) == 0 {
+		fmt.Println("Warning: allowed_app_names is empty. Accepting requests from all app names")
+	} else {
+		// Convert list up to a map to make lookups easier
+		cfg.allowedAppNameMap = make(map[string]bool)
+		for _, app := range cfg.AllowedAppNames {
+			cfg.allowedAppNameMap[app] = true
+		}
+	}
+
 	return &cfg, nil
 }

--- a/main.go
+++ b/main.go
@@ -217,5 +217,4 @@ func loadConfig(configPath string) (*config, error) {
 		return nil, err
 	}
 	return &cfg, nil
-
 }

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -8,6 +8,10 @@ listings_auth_pass: secret
 # report to the GitHub issue. If unspecified, based on the listen address.
 # api_prefix: https://riot.im/bugreports
 
+# List of approved AppNames we accept. Names not in the list or missing an application name will be rejected.
+# An empty or missing list will retain legacy behaviour and permit reports from any application name.
+allowed_app_names: []
+
 # a GitHub personal access token (https://github.com/settings/tokens), which
 # will be used to create a GitHub issue for each report. It requires
 # `public_repo` scope. If omitted, no issues will be created.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,6 +7,9 @@
 
 set -eu
 
+echo "golint:"
 golint -set_exit_status
+echo "go vet:"
 go vet -vettool=$(which shadow)
+echo "go cyclo:"
 gocyclo -over 12 .

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -11,5 +11,5 @@ echo "golint:"
 golint -set_exit_status
 echo "go vet:"
 go vet -vettool=$(which shadow)
-echo "go cyclo:"
+echo "gocyclo:"
 gocyclo -over 12 .

--- a/submit.go
+++ b/submit.go
@@ -193,7 +193,7 @@ func (s *submitServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Filter out unwanted rageshakes, if a list is defined
-	if !s.allowedAppNameMap[p.AppName] {
+	if len(s.allowedAppNameMap) != 0 && !s.allowedAppNameMap[p.AppName] {
 		log.Printf("Blocking rageshake because app name %s not in list", p.AppName)
 		if err := os.RemoveAll(reportDir); err != nil {
 			log.Printf("Unable to remove report dir %s after rejected upload: %v\n",

--- a/submit.go
+++ b/submit.go
@@ -58,6 +58,7 @@ type submitServer struct {
 	slack *slackClient
 
 	genericWebhookClient *http.Client
+	allowedAppNameMap    map[string]bool
 	cfg                  *config
 }
 
@@ -192,7 +193,7 @@ func (s *submitServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Filter out unwanted rageshakes, if a list is defined
-	if len(s.cfg.AllowedAppNames) != 0 && !s.cfg.allowedAppNameMap[p.AppName] {
+	if !s.allowedAppNameMap[p.AppName] {
 		log.Printf("Blocking rageshake because app name %s not in list", p.AppName)
 		if err := os.RemoveAll(reportDir); err != nil {
 			log.Printf("Unable to remove report dir %s after rejected upload: %v\n",

--- a/submit.go
+++ b/submit.go
@@ -192,7 +192,7 @@ func (s *submitServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Filter out unwanted rageshakes, if a list is defined
-	if len(s.cfg.AllowedAppNames) != 0 && !s.cfg.AllowedAppNameMap[p.AppName] {
+	if len(s.cfg.AllowedAppNames) != 0 && !s.cfg.allowedAppNameMap[p.AppName] {
 		log.Printf("Blocking rageshake because app name %s not in list", p.AppName)
 		if err := os.RemoveAll(reportDir); err != nil {
 			log.Printf("Unable to remove report dir %s after rejected upload: %v\n",

--- a/submit.go
+++ b/submit.go
@@ -191,6 +191,17 @@ func (s *submitServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Filter out unwanted rageshakes, if a list is defined
+	if len(s.cfg.AllowedAppNames) != 0 && !s.cfg.AllowedAppNameMap[p.AppName] {
+		log.Printf("Blocking rageshake because app name %s not in list", p.AppName)
+		if err := os.RemoveAll(reportDir); err != nil {
+			log.Printf("Unable to remove report dir %s after rejected upload: %v\n",
+				reportDir, err)
+		}
+		http.Error(w, "This server does not accept rageshakes from your application. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", 400)
+		return
+	}
+
 	// We use this prefix (eg, 2022-05-01/125223-abcde) as a unique identifier for this rageshake.
 	// This is going to be used to uniquely identify rageshakes, even if they are not submitted to
 	// an issue tracker for instance with automatic rageshakes that can be plentiful
@@ -243,6 +254,7 @@ func parseRequest(w http.ResponseWriter, req *http.Request, reportDir string) *p
 		http.Error(w, fmt.Sprintf("Could not decode payload: %s", err.Error()), 400)
 		return nil
 	}
+
 	return p
 }
 
@@ -273,35 +285,13 @@ func parseJSONRequest(w http.ResponseWriter, req *http.Request, reportDir string
 		}
 	}
 
-	// backwards-compatibility hack: current versions of riot-android
-	// don't set 'app', so we don't correctly file github issues.
-	if p.AppName == "" && p.UserAgent == "Android" {
-		parsed.AppName = "riot-android"
+	parsed.AppName = p.AppName
 
-		// they also shove lots of stuff into 'Version' which we don't really
-		// want in the github report
-		for _, line := range strings.Split(p.Version, "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" {
-				continue
-			}
-			parts := strings.SplitN(line, ":", 2)
-			key := strings.TrimSpace(parts[0])
-			val := ""
-			if len(parts) > 1 {
-				val = strings.TrimSpace(parts[1])
-			}
-			parsed.Data[key] = val
-		}
-	} else {
-		parsed.AppName = p.AppName
-
-		if p.UserAgent != "" {
-			parsed.Data["User-Agent"] = p.UserAgent
-		}
-		if p.Version != "" {
-			parsed.Data["Version"] = p.Version
-		}
+	if p.UserAgent != "" {
+		parsed.Data["User-Agent"] = p.UserAgent
+	}
+	if p.Version != "" {
+		parsed.Data["Version"] = p.Version
 	}
 
 	return &parsed, nil

--- a/submit_test.go
+++ b/submit_test.go
@@ -108,36 +108,6 @@ func TestJsonUpload(t *testing.T) {
 	checkUploadedFile(t, reportDir, "logs-0000.log.gz", true, "line1\nline2")
 }
 
-// check that we can unpick the json submitted by the android clients
-func TestUnpickAndroidMangling(t *testing.T) {
-	body := `{"text": "test ylc 001",
-"version": "User : @ylc8001:matrix.org\nPhone : Lenovo P2a42\nVector version: 0:6:9\n",
-"user_agent": "Android"
-}`
-	p, _ := testParsePayload(t, body, "", "")
-	if p == nil {
-		t.Fatal("parseRequest returned nil")
-	}
-	if p.UserText != "test ylc 001" {
-		t.Errorf("user text: got %s, want %s", p.UserText, "test ylc 001")
-	}
-	if p.AppName != "riot-android" {
-		t.Errorf("appname: got %s, want %s", p.AppName, "riot-android")
-	}
-	if p.Data["Version"] != "" {
-		t.Errorf("version: got %s, want ''", p.Data["Version"])
-	}
-	if p.Data["User"] != "@ylc8001:matrix.org" {
-		t.Errorf("data.user: got %s, want %s", p.Data["User"], "@ylc8001:matrix.org")
-	}
-	if p.Data["Phone"] != "Lenovo P2a42" {
-		t.Errorf("data.phone: got %s, want %s", p.Data["Phone"], "Lenovo P2a42")
-	}
-	if p.Data["Vector version"] != "0:6:9" {
-		t.Errorf("data.version: got %s, want %s", p.Data["Version"], "0:6:9")
-	}
-}
-
 func TestMultipartUpload(t *testing.T) {
 	reportDir := mkTempDir(t)
 	defer os.RemoveAll(reportDir)

--- a/submit_test.go
+++ b/submit_test.go
@@ -103,7 +103,6 @@ func TestAppNames(t *testing.T) {
 	if submitSimpleRequestToServer(t, emptyAppNameMap, body) != 200 {
 		t.Fatal("empty map did not allow all")
 	}
-
 }
 
 func TestEmptyJson(t *testing.T) {


### PR DESCRIPTION
Optionally admins can now set a list of application names that will be accepted by this server. 

This is in reaction to admins spending time triaging bug reports for applications they don't own / can't do anything with.

The behaviour will stay as before (all applications permitted)  if the option is unset or an empty list; but will log a new warning on startup to say this behaviour is occuring.

If the report is blocked, the error message will include a link to the docs/blocked_rageshake.md file which contains some pointers on why and what to do afterwards; This isn't strictly neccessary but should ease peoples' debugging flows from that point.