### PR TITLE
Extra automation for release process (building binaries and docker containers)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
         run: tar -czf rageshake.tar.gz rageshake
       - name: Upload tarball to matching release
         if: github.event.release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           files: rageshake.tar.gz
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,18 @@
-name: Linting and checks
+name: Linting, build, test and release
+
+# Runs on each PR to lint and test
+
+# Runs on each release (via github UI) to lint and test, then upload binary to the release
 
 on:
   pull_request:
   push:
     branches: [master]
+  release: 
+    types: [created]
+
+permissions:
+  contents: write
 
 jobs:
   changelog:
@@ -46,3 +55,14 @@ jobs:
         run: go build
       - name: Test
         run: go test
+      - name: Create tarball for release
+        if: github.event.release
+        run: tar -czf rageshake.tar.gz rageshake
+      - name: Upload tarball to matching release
+        if: github.event.release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: rageshake.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 1. Set a variable to the version number for convenience:
    ```sh
-   ver=x.y
+   ver=x.y.z
    ```
 1. Update the changelog:
    ```sh
@@ -15,16 +15,19 @@
 1. Sanity-check the
    [changelog](https://github.com/matrix-org/rageshake/blob/master/CHANGES.md)
    and update if need be.
-1. Create a signed tag for the release:
-   ```sh
-   git tag -s v$ver
-   ```
-   Base the tag message on the changelog.
-1. Push the tag:
-   ```sh
-   git push origin tag v$ver
-   ```
 1. Create release on GH project page:
    ```sh
-   xdg-open https://github.com/matrix-org/rageshake/releases/edit/v$ver
+   xdg-open https://github.com/matrix-org/rageshake/releases/new
+   ```
+   Set the tag to be the new version (eg v2.2.1).
+    Ensure you selected "create tag" if it doesn't already exist.
+    Release name will be autocompleted to the tag name
+   Describe the release based on the changelog
+1. Check that the docker image has been created and tagged (a few mins)
+   ```
+   xdg-open https://github.com/matrix-org/rageshake/pkgs/container/rageshake/versions?filters%5Bversion_type%5D=tagged
+   ```
+1. Check that the rageshake binary has been built and added to the release (a few mins)
+   ```
+   xdg-open https://github.com/matrix-org/rageshake/releases
    ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,9 +20,14 @@
    xdg-open https://github.com/matrix-org/rageshake/releases/new
    ```
    Set the tag to be the new version (eg v2.2.1).
-    Ensure you selected "create tag" if it doesn't already exist.
-    Release name will be autocompleted to the tag name
+   
+   Ensure you selected "create tag" if it doesn't already exist.
+   
+   Release name will be autocompleted to the tag name
+   
    Describe the release based on the changelog
+   
+   This will trigger a docker image to be built as well as a binary to be uploaded to the release
 1. Check that the docker image has been created and tagged (a few mins)
    ```
    xdg-open https://github.com/matrix-org/rageshake/pkgs/container/rageshake/versions?filters%5Bversion_type%5D=tagged

--- a/changelog.d/70.misc
+++ b/changelog.d/70.misc
@@ -1,0 +1,1 @@
+Update deployment process to automatically build docker containers and binaries.


### PR DESCRIPTION
Updates the release process such that creation of a github Release will be enough to trigger the docker image build and the rageshake.tar.gz to be uploaded to the release.

Requires that we move to a full "semver" semantic version in order to trigger the various tools to work; so no more `v1.8` ; we should use  `v1.9.0`.

Fixes #69  
Fixes #51 