### PR TITLE
Refactor docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,11 +45,25 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},suffix=-debug
             type=semver,pattern={{major}},suffix=-debug
             type=sha,suffix=-debug
+      
+      - name: Docker meta (scripts variant)
+        id: meta-scripts
+        uses: docker/metadata-action@v3
+        with:
+          images: "${{ env.IMAGE }}/scripts"
+          bake-target: docker-metadata-action-scripts
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
       - name: Merge buildx bake files
         run: |
-            jq -s '.[0] * .[1]' ${{ steps.meta.outputs.bake-file }} ${{ steps.meta-debug.outputs.bake-file }} > docker-bake.override.json
-
+            jq -s '.[0] * .[1] * .[2]' ${{ steps.meta.outputs.bake-file }} ${{ steps.meta-debug.outputs.bake-file }} ${{ steps.meta-scripts.outputs.bake-file }} > docker-bake.override.json
+      - name: Debug bake override file
+        run: cat docker-bake.override.json
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -84,7 +84,7 @@ jobs:
       # For pull-requests, only read from the cache, do not try to push to the
       # cache or the image itself
       - name: Build
-        uses: docker/bake-action@v1
+        uses: docker/bake-action@v2
         if: github.event_name == 'pull_request'
         with:
           files: |
@@ -96,7 +96,7 @@ jobs:
             base.cache-from=type=registry,ref=${{ env.IMAGE }}:buildcache
 
       - name: Build and push
-        uses: docker/bake-action@v1
+        uses: docker/bake-action@v2
         if: github.event_name != 'pull_request'
         with:
           files: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,6 +32,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+          flavor: |
+            latest=auto
 
       - name: Docker meta (debug variant)
         id: meta-debug
@@ -40,11 +42,14 @@ jobs:
           images: "${{ env.IMAGE }}"
           bake-target: docker-metadata-action-debug
           tags: |
-            type=ref,event=branch,suffix=-debug
-            type=semver,pattern={{version}},suffix=-debug
-            type=semver,pattern={{major}}.{{minor}},suffix=-debug
-            type=semver,pattern={{major}},suffix=-debug
-            type=sha,suffix=-debug
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+          flavor: |
+            latest=false
+            suffix=-debug
       
       - name: Docker meta (scripts variant)
         id: meta-scripts
@@ -58,6 +63,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+          flavor: |
+            latest=auto
 
       - name: Merge buildx bake files
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -66,11 +66,6 @@ jobs:
           flavor: |
             latest=auto
 
-      - name: Merge buildx bake files
-        run: |
-            jq -s '.[0] * .[1] * .[2]' ${{ steps.meta.outputs.bake-file }} ${{ steps.meta-debug.outputs.bake-file }} ${{ steps.meta-scripts.outputs.bake-file }} > docker-bake.override.json
-      - name: Debug bake override file
-        run: cat docker-bake.override.json
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
@@ -92,6 +87,11 @@ jobs:
         uses: docker/bake-action@v1
         if: github.event_name == 'pull_request'
         with:
+          files: |
+            docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+            ${{ steps.meta-debug.outputs.bake-file }}
+            ${{ steps.meta-scripts.outputs.bake-file }}
           set: |
             base.cache-from=type=registry,ref=${{ env.IMAGE }}:buildcache
 
@@ -99,6 +99,11 @@ jobs:
         uses: docker/bake-action@v1
         if: github.event_name != 'pull_request'
         with:
+          files: |
+            docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+            ${{ steps.meta-debug.outputs.bake-file }}
+            ${{ steps.meta-scripts.outputs.bake-file }}
           set: |
             base.output=type=image,push=true
             base.cache-from=type=registry,ref=${{ env.IMAGE }}:buildcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o rageshake
 
+## Runtime stage, python scripts ##
+FROM python:3-slim AS scripts
+COPY scripts/cleanup.py .
+WORKDIR /
+
 ## Runtime stage, debug variant ##
 FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static-debian${DEBIAN_VERSION}:debug-nonroot AS debug
 COPY --from=builder /build/rageshake /rageshake

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o rageshake
 
 ## Runtime stage, python scripts ##
 FROM python:3-slim AS scripts
-COPY scripts/cleanup.py .
+COPY scripts/cleanup.py /cleanup.py
 WORKDIR /
 
 ## Runtime stage, debug variant ##

--- a/changelog.d/71.misc
+++ b/changelog.d/71.misc
@@ -1,0 +1,1 @@
+Creates a new `rageshake/scripts` image with cleanup script, ensure `latest` tag is correctly applied.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,9 +1,10 @@
 // This is what is baked by GitHub Actions
-group "default" { targets = ["regular", "debug"] }
+group "default" { targets = ["regular", "debug", "scripts"] }
 
-// Targets filled by GitHub Actions: one for the regular tag, one for the debug tag
+// Targets filled by GitHub Actions for each tag
 target "docker-metadata-action" {}
 target "docker-metadata-action-debug" {}
+target "docker-metadata-action-scripts" {}
 
 // This sets the platforms and is further extended by GitHub Actions to set the
 // output and the cache locations
@@ -22,4 +23,9 @@ target "regular" {
 target "debug" {
   inherits = ["base", "docker-metadata-action-debug"]
   target = "debug"
+}
+
+target "scripts" {
+  inherits = ["base", "docker-metadata-action-scripts"]
+  target = "scripts"
 }


### PR DESCRIPTION
The two changes are:
 - do not tag both rageshake and the -debug flavour as `latest` - only the main build.
 - Create a python:3-slim based container to host the scripts for usage.

Tested on this fork of the repo; we can see:

 - the correct version is tagged `latest` here: https://github.com/michaelkaye/rageshake/pkgs/container/rageshake/versions?filters[version_type]=tagged 
 - the new docker container holding the script is here: https://github.com/michaelkaye/rageshake/pkgs/container/rageshake/scripts/versions?filters[version_type]=tagged
 - the new docker container contains the script and works at a basic level
 
 ```
 michaelk@michaelk-XPS-13-9370:~$ docker run -it ghcr.io/michaelkaye/rageshake/scripts:latest python cleanup.py -h
usage: cleanup.py [-h] (--max-days MAX_DAYS | --days-to-check DAYS_TO_CHECK)
                  [--exclude-mxids-file EXCLUDE_MXIDS_FILE] [--dry-run] --path
                  PATH
                  LIMIT [LIMIT ...]

Cleanup rageshake files on disk

positional arguments:
  LIMIT                 application_name retention limits in days (each
                        formatted app-name:10)

options:
  -h, --help            show this help message and exit
  --max-days MAX_DAYS   Search all days until this maximum
  --days-to-check DAYS_TO_CHECK
                        Explicitly supply days in the past to check for
                        deletion, eg '1,2,3,5'
  --exclude-mxids-file EXCLUDE_MXIDS_FILE
                        Supply a text file containing one mxid per line to
                        exclude from cleanup. Blank lines and lines starting #
                        are ignored.
  --dry-run             Dry run (do not delete)
  --path PATH           Root path of rageshakes (eg /home/rageshakes/bugs/)
```