### PR TITLE
Enhance scripts/cleanup.py to be able to run as a continual task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,15 @@ Details on the request and expected response are [available](docs/generic\_webho
 
 ## Cleanup script
 
-A python script is provided in scripts/cleanup.py and in a docker container. It can be configured
-using the commandline options to filter rageshakes in a given date range.
+A python script is provided in scripts/cleanup.py and in a
+[docker container](https://github.com/orgs/matrix-org/packages/container/package/rageshake%2Fscripts).
+It can be configured using the commandline options available via `cleaup.py --help`.
 
 It can either be run via a cronjob at appropriate intervals (typically daily), or
 be set to run in a continual mode with something like `--repeat-delay-hours 24`
 to repeat running after approximately 24 hours.
 
-Note that this script will scan all logs older than the smallest configured retention period, up to the limit specified by --max-days. This can be an IO and CPU intensive process. 
+Note that this script will scan all logs older than the smallest configured retention period,
+up to the limit specified by `--max-days` or each of the days in `--days-to-check`.
+This can be an IO and CPU intensive process if a large number of files are scanned.
+

--- a/README.md
+++ b/README.md
@@ -127,5 +127,4 @@ It can either be run via a cronjob at appropriate intervals (typically daily), o
 be set to run in a continual mode with something like `--repeat-delay-hours 24`
 to repeat running after approximately 24 hours.
 
-Be aware that each run will scan all files between --max-days and the smallest retention period set,
-ensuring we always have up to date information, however this may be an intensive process.
+Note that this script will scan all logs older than the smallest configured retention period, up to the limit specified by --max-days. This can be an IO and CPU intensive process. 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,10 @@ Details on the request and expected response are [available](docs/generic\_webho
 ## Cleanup script
 
 A python script is provided in scripts/cleanup.py and in a docker container. It can be configured
-using the commandline options to filter rageshakes in a given date range. It is expected to be
-run as a cronjob on a daily basis.
+using the commandline options to filter rageshakes in a given date range.
 
-The script is idempotent enough to be re-runnable on a more frequent basis if required. If a cronjob
-cannot be configured, it can be run in a continual mode with something like `--repeat-delay-hours 24`
+It can either be run via a cronjob at appropriate intervals (typically daily), or
+be set to run in a continual mode with something like `--repeat-delay-hours 24`
 to repeat running after approximately 24 hours.
 
 Be aware that each run will scan all files between --max-days and the smallest retention period set,

--- a/README.md
+++ b/README.md
@@ -117,3 +117,16 @@ issues created.
 
 Details on the request and expected response are [available](docs/generic\_webhook.md).
 
+
+## Cleanup script
+
+A python script is provided in scripts/cleanup.py and in a docker container. It can be configured
+using the commandline options to filter rageshakes in a given date range. It is expected to be
+run as a cronjob on a daily basis.
+
+The script is idempotent enough to be re-runnable on a more frequent basis if required. If a cronjob
+cannot be configured, it can be run in a continual mode with something like `--repeat-delay-hours 24`
+to repeat running after approximately 24 hours.
+
+Be aware that each run will scan all files between --max-days and the smallest retention period set,
+ensuring we always have up to date information, however this may be an intensive process.

--- a/changelog.d/72.feature
+++ b/changelog.d/72.feature
@@ -1,0 +1,1 @@
+Add --repeat-delay-hours option to cleanup script to run persistently outside of a cronjob.

--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -205,7 +205,10 @@ def main():
         "--repeat-delay-hours",
         dest="repeat_delay_hours",
         type=float,
-        help="After each execution, wait this number of hours then run again. An alternative to configuring a cronjob for ongoing cleanup.",
+        help="""
+            Instead of exiting after execution, run repeatedly, waiting this number of hours between each execution.
+            An alternative to configuring a cronjob for ongoing cleanup.
+            """,
     )
 
     args = parser.parse_args()

--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -213,7 +213,7 @@ def main():
 
     args = parser.parse_args()
 
-    if args.repeat_delay_hours:
+    if args.repeat_delay_hours is defined:
         while True:
             execute(args)
             print("I =====================================================")

--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -228,7 +228,7 @@ def execute(args) -> None:
     """
     Creation, configuration and execution of a cleanup task based on args.
 
-    Allows exceptions to propigate to the caller for handling.
+    Allows exceptions to propagate to the caller for handling.
     """
 
     application_limits: Dict[str, int] = {}

--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -204,13 +204,13 @@ def main():
     parser.add_argument(
         "--repeat-delay-hours",
         dest="repeat_delay_hours",
-        type=int,
+        type=float,
         help="After each execution, wait this number of hours then run again. An alternative to configuring a cronjob for ongoing cleanup.",
     )
 
     args = parser.parse_args()
 
-    if args.repeat_after:
+    if args.repeat_delay_hours:
         while True:
             execute(args)
             print("I =====================================================")


### PR DESCRIPTION
This is useful in the situation where you want to run this as a sidecar in a k8s pod, because while k8s has the concept of a CronJob - it doesn't run within the same pod; so you'd end up with two pods both needing to mount a block device (say, where you keep the bugs) read-write; which I don't believe works well. 

Have tested it with an invocation like this to test every 0.01 hours, which ran as expected
`michaelk@michaelk-XPS-13-9370:~/work/rageshake$ ./scripts/cleanup.py --repeat-delay-hours 0.01 --max-days 100 --path /home/michaelk/bugs/ --dry-run element-web:10` 

The following both run exactly once, which seems valid.

`michaelk@michaelk-XPS-13-9370:~/work/rageshake$ ./scripts/cleanup.py --repeat-delay-hours 0 --max-days 100 --path /home/michaelk/bugs/ --dry-run element-web:10` 
and
`michaelk@michaelk-XPS-13-9370:~/work/rageshake$ ./scripts/cleanup.py --max-days 100 --path /home/michaelk/bugs/ --dry-run element-web:10` 

While I haven't done a comprehensive check for leaks, running this over a period of time shows memory usage as flat, and lsof didn't reveal any file descriptors being held onto incorrectly, so I think the continual recreation of the Cleanup object is keeping things tidy.