### PR TITLE
Allow gzipped json & txt

### DIFF
--- a/logserver.go
+++ b/logserver.go
@@ -104,8 +104,10 @@ func serveFile(w http.ResponseWriter, r *http.Request, path string) {
 //
 // Unlike mime.TypeByExtension, the results are limited to a set of types which
 // should be safe to serve to a browser without introducing XSS vulnerabilities.
+// These match file file extensions we allow on upload, plus 'log' which we use
+// for the log files.
 func extensionToMimeType(path string) string {
-	if strings.HasSuffix(path, ".txt") {
+	if strings.HasSuffix(path, ".txt") || strings.HasSuffix(path, ".log") {
 		// anyone uploading text in anything other than utf-8 needs to be
 		// re-educated.
 		return "text/plain; charset=utf-8"
@@ -236,7 +238,13 @@ func addToArchive(targz *tar.Writer, dfilename string, filename string) error {
 }
 
 func serveGzippedFile(w http.ResponseWriter, r *http.Request, path string, size int64) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	cType := "text/plain; charset=utf-8"
+	if strings.HasSuffix(path, ".gz") {
+		cType = extensionToMimeType(path[:len(path)-len(".gz")])
+	} else {
+
+	}
+	w.Header().Set("Content-Type", cType)
 
 	acceptsGzip := false
 	splitRune := func(s rune) bool { return s == ' ' || s == '\t' || s == '\n' || s == ',' }

--- a/submit.go
+++ b/submit.go
@@ -405,12 +405,13 @@ func formPartToPayload(field, data string, p *payload) {
 // * a limited set of extensions. We are careful to limit the content-types
 //   we will serve the files with, but somebody might accidentally point an
 //   Apache or nginx at the upload directory, which would serve js files as
-//   application/javascript and open XSS vulnerabilities.
+//   application/javascript and open XSS vulnerabilities. We also allow gzipped
+//   text and json on the same basis (there's really no sense allowing gzipped images).
 //
 // * no silly characters (/, ctrl chars, etc)
 //
 // * nothing starting with '.'
-var filenameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_-]+\.(jpg|png|txt|json)$`)
+var filenameRegexp = regexp.MustCompile(`^[a-zA-Z0-9_-]+\.(jpg|png|txt|json|txt\.gz|json\.gz)$`)
 
 // saveFormPart saves a file upload to the report directory.
 //


### PR DESCRIPTION
Adds just these two specific extensions to the allow list, which will then automatically trigger the gzip-on-download. Make the gzip-on-download determine the filetype from the file extension like the non gzip path.

Fixes https://github.com/matrix-org/rageshake/issues/73