### PR TITLE
add link to archive in the submitted issue

### DIFF
--- a/changelog.d/81.feature
+++ b/changelog.d/81.feature
@@ -1,0 +1,1 @@
+Add a link to the archive containing all the logs in the webhook's body

--- a/changelog.d/81.feature
+++ b/changelog.d/81.feature
@@ -1,1 +1,1 @@
-Add a link to the archive containing all the logs in the webhook's body
+Add a link to the archive containing all the logs in the issue body.

--- a/submit.go
+++ b/submit.go
@@ -670,6 +670,7 @@ func buildGenericIssueRequest(p payload, listingURL string) (title, body string)
 
 	// Add log links to the body
 	fmt.Fprintf(bodyBuf, "\n[Logs](%s)", listingURL)
+	fmt.Fprintf(bodyBuf, " ([archive](%s))", listingURL+"?format=tar.gz")
 
 	for _, file := range p.Files {
 		fmt.Fprintf(


### PR DESCRIPTION
This adds a link to the full archive of the rageshake logs, avoiding a few manual steps to download them. For what it's worth, the server will happily respond with the full archive even in the presence of a trailing slash in the `listingURL` (it might be an HTTP thing).