### PR TITLE
Generate emails and github/gitlab issue bodies from a template

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+UNRELEASED
+==========
+
+Features
+--------
+
+- Allow configuration of the body of created Github/Gitlab issues via a template in the configuration file. ([\#84](https://github.com/matrix-org/rageshake/issues/84))
+
+
 1.11.0 (2023-08-11)
 ===================
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Optional parameters:
 
 ## Issue template
 
-It is possible to specify a template in the configuration file which will be used to build the
-body of any issues created on Github or Gitlab, via the `issue_body_template_file` setting. See
-[templates/README.md](templates/README.md) for more information.
+It is possible to override the templates used to construct emails, and Github and Gitlab issues.
+See [templates/README.md](templates/README.md) for more information.
 
 ## HTTP endpoints
 

--- a/README.md
+++ b/README.md
@@ -21,25 +21,8 @@ Optional parameters:
 ## Issue template
 
 It is possible to specify a template in the configuration file which will be used to build the
-body of any issues created on Github or Gitlab, via the `issue_body_template` setting.
-See [rageshake.sample.yaml](rageshake.sample.yaml) for an example.
-
-See https://pkg.go.dev/text/template#pkg-overview for documentation of the template language.
-
-The following properties are defined on the input (accessible via `.` or `$`):
-
-| Name         | Type                | Description                                                                                       |
-|--------------|---------------------|---------------------------------------------------------------------------------------------------|
-| `ID`         | `string`            | The unique ID for this rageshake.                                                                 |
-| `UserText`   | `string`            | A multi-line string containing the user description of the fault (from `text` in the submission). |
-| `AppName`    | `string`            | A short slug to identify the app making the report (from `app` in the submission).                |
-| `Labels`     | `[]string`          | A list of labels requested by the application.                                                    |
-| `Data`       | `map[string]string` | A map of other key/value pairs included in the submission.                                        |
-| `Logs`       | `[]string`          | A list of log file names.                                                                         |
-| `LogErrors`  | `[]string`          | Set if there are log parsing errors.                                                              |
-| `Files`      | `[]string`          | A list of other files (not logs) uploaded as part of the rageshake.                               |
-| `FileErrors` | `[]string`          | Set if there are file parsing errors.                                                             |
-| `ListingURL` | `string`            | Complete link to the listing URL that contains all uploaded logs.                                 |
+body of any issues created on Github or Gitlab, via the `issue_body_template` setting. See
+[templates/README.md](templates/README.md) for more information.
 
 ## HTTP endpoints
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Optional parameters:
 ## Issue template
 
 It is possible to specify a template in the configuration file which will be used to build the
-body of any issues created on Github or Gitlab, via the `issue_body_template` setting. See
+body of any issues created on Github or Gitlab, via the `issue_body_template_file` setting. See
 [templates/README.md](templates/README.md) for more information.
 
 ## HTTP endpoints

--- a/README.md
+++ b/README.md
@@ -18,6 +18,29 @@ Optional parameters:
  * `-listen <address>`: TCP network address to listen for HTTP requests
    on. Example: `:9110`.
 
+## Issue template
+
+It is possible to specify a template in the configuration file which will be used to build the
+body of any issues created on Github or Gitlab, via the `issue_body_template` setting.
+See [rageshake.sample.yaml](rageshake.sample.yaml) for an example.
+
+See https://pkg.go.dev/text/template#pkg-overview for documentation of the template language.
+
+The following properties are defined on the input (accessible via `.` or `$`):
+
+| Name         | Type                | Description                                                                                       |
+|--------------|---------------------|---------------------------------------------------------------------------------------------------|
+| `ID`         | `string`            | The unique ID for this rageshake.                                                                 |
+| `UserText`   | `string`            | A multi-line string containing the user description of the fault (from `text` in the submission). |
+| `AppName`    | `string`            | A short slug to identify the app making the report (from `app` in the submission).                |
+| `Labels`     | `[]string`          | A list of labels requested by the application.                                                    |
+| `Data`       | `map[string]string` | A map of other key/value pairs included in the submission.                                        |
+| `Logs`       | `[]string`          | A list of log file names.                                                                         |
+| `LogErrors`  | `[]string`          | Set if there are log parsing errors.                                                              |
+| `Files`      | `[]string`          | A list of other files (not logs) uploaded as part of the rageshake.                               |
+| `FileErrors` | `[]string`          | Set if there are file parsing errors.                                                             |
+| `ListingURL` | `string`            | Complete link to the listing URL that contains all uploaded logs.                                 |
+
 ## HTTP endpoints
 
 The following HTTP endpoints are exposed:

--- a/main.go
+++ b/main.go
@@ -37,20 +37,12 @@ import (
 
 	"gopkg.in/yaml.v2"
 )
+import _ "embed"
 
-// DefaultIssueBodyTemplate is the default template used for `issue_body_template` in the config.
+// DefaultIssueBodyTemplate is the default template used for `issue_body_template_file` in the config.
 //
-// !!! Keep in step with the documentation in `rageshake.sample.yaml` !!!
-const DefaultIssueBodyTemplate = `User message:
-{{ .UserText }}
-
-{{ range $key, $val := .Data -}}
-{{ $key }}: ` + "`{{ $val }}`" + `
-{{ end }}
-[Logs]({{ .ListingURL }}) ([archive]({{ .ListingURL }}?format=tar.gz))
-{{- range $file := .Files}} / [{{ $file }}]({{ $.ListingURL }}/{{ $file }})
-{{- end }}
-`
+//go:embed templates/issue_body.tmpl
+var DefaultIssueBodyTemplate string
 
 var configPath = flag.String("config", "rageshake.yaml", "The path to the config file. For more information, see the config file in this repository.")
 var bindAddr = flag.String("listen", ":9110", "The port to listen on.")

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ type config struct {
 	GitlabProjectLabels     map[string][]string `yaml:"gitlab_project_labels"`
 	GitlabIssueConfidential bool                `yaml:"gitlab_issue_confidential"`
 
-	IssueBodyTemplate string `yaml:"issue_body_template"`
+	IssueBodyTemplateFile string `yaml:"issue_body_template_file"`
 
 	SlackWebhookURL string `yaml:"slack_webhook_url"`
 
@@ -205,13 +205,18 @@ func main() {
 }
 
 func parseIssueTemplate(cfg *config) *template.Template {
-	issueTemplate := cfg.IssueBodyTemplate
-	if issueTemplate == "" {
-		issueTemplate = DefaultIssueBodyTemplate
+	issueTemplate := DefaultIssueBodyTemplate
+	issueTemplateFile := cfg.IssueBodyTemplateFile
+	if issueTemplateFile != "" {
+		issueTemplateBytes, err := os.ReadFile(issueTemplateFile)
+		if err != nil {
+			log.Fatalf("Unable to read template file `%s`: %s", issueTemplateFile, err)
+		}
+		issueTemplate = string(issueTemplateBytes)
 	}
 	parsedIssueTemplate, err := template.New("issue").Parse(issueTemplate)
 	if err != nil {
-		log.Fatalf("Invalid `issue_template` in config file: %s", err)
+		log.Fatalf("Invalid `issue body template` in config file: %s", err)
 	}
 	return parsedIssueTemplate
 }

--- a/main.go
+++ b/main.go
@@ -213,22 +213,22 @@ func main() {
 
 // parseTemplate parses a template file, with fallback to default.
 //
-// If `configFileSettingValue` is non-empty, it is used as the name of a file to read. Otherwise, `defaultTemplate` is
+// If `templateFilePath` is non-empty, it is used as the name of a file to read. Otherwise, `defaultTemplate` is
 // used.
 //
 // The template text is then parsed into a template named `templateName`.
-func parseTemplate(defaultTemplate string, configFileSettingValue string, templateName string) *template.Template {
+func parseTemplate(defaultTemplate string, templateFilePath string, templateName string) *template.Template {
 	templateText := defaultTemplate
-	if configFileSettingValue != "" {
-		issueTemplateBytes, err := os.ReadFile(configFileSettingValue)
+	if templateFilePath != "" {
+		issueTemplateBytes, err := os.ReadFile(templateFilePath)
 		if err != nil {
-			log.Fatalf("Unable to read template file `%s`: %s", configFileSettingValue, err)
+			log.Fatalf("Unable to read template file `%s`: %s", templateFilePath, err)
 		}
 		templateText = string(issueTemplateBytes)
 	}
 	parsedTemplate, err := template.New(templateName).Parse(templateText)
 	if err != nil {
-		log.Fatalf("Invalid template file %s in config file: %s", configFileSettingValue, err)
+		log.Fatalf("Invalid template file %s in config file: %s", templateFilePath, err)
 	}
 	return parsedTemplate
 }

--- a/main.go
+++ b/main.go
@@ -44,6 +44,11 @@ import _ "embed"
 //go:embed templates/issue_body.tmpl
 var DefaultIssueBodyTemplate string
 
+// DefaultEmailBodyTemplate is the default template used for `email_body_template_file` in the config.
+//
+//go:embed templates/email_body.tmpl
+var DefaultEmailBodyTemplate string
+
 var configPath = flag.String("config", "rageshake.yaml", "The path to the config file. For more information, see the config file in this repository.")
 var bindAddr = flag.String("listen", ":9110", "The port to listen on.")
 
@@ -71,6 +76,7 @@ type config struct {
 	GitlabIssueConfidential bool                `yaml:"gitlab_issue_confidential"`
 
 	IssueBodyTemplateFile string `yaml:"issue_body_template_file"`
+	EmailBodyTemplateFile string `yaml:"email_body_template_file"`
 
 	SlackWebhookURL string `yaml:"slack_webhook_url"`
 
@@ -169,6 +175,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 	http.Handle("/api/submit", &submitServer{
 		issueTemplate:        parseTemplate(DefaultIssueBodyTemplate, cfg.IssueBodyTemplateFile, "issue"),
+		emailTemplate:        parseTemplate(DefaultEmailBodyTemplate, cfg.EmailBodyTemplateFile, "email"),
 		ghClient:             ghClient,
 		glClient:             glClient,
 		apiPrefix:            apiPrefix,

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -23,7 +23,7 @@ github_project_mappings:
 
 # A template for the body of Github and Gitlab issues. The default template is as shown below.
 #
-# See `README.md` for more information on what can be specified here.
+# See `templates/README.md` for more information on what can be specified here.
 issue_body_template: |
   {{ .UserText }}
   

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -21,18 +21,9 @@ github_token: secrettoken
 github_project_mappings:
    my-app: octocat/HelloWorld
 
-# A template for the body of Github and Gitlab issues. The default template is as shown below.
-#
-# See `templates/README.md` for more information on what can be specified here.
-issue_body_template: |
-  {{ .UserText }}
-  
-  {{ range $key, $val := .Data -}}
-  {{ $key }}: `{{ $val }}`
-  {{ end }}
-  [Logs]({{ .ListingURL }}) ([archive]({{ .ListingURL }}?format=tar.gz))
-  {{- range $file := .Files}} / [{{ $file }}]({{ $.ListingURL }}/{{ $file }})
-  {{- end }}
+# The path of a template for the body of Github and Gitlab issues. See `templates/README.md` for more information on
+# the templates.
+issue_body_template_file: path/to/issue_body.tmpl
 
 # a GitLab personal access token (https://gitlab.com/-/profile/personal_access_tokens), which
 # will be used to create a GitLab issue for each report. It requires

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -21,10 +21,6 @@ github_token: secrettoken
 github_project_mappings:
    my-app: octocat/HelloWorld
 
-# The path of a template for the body of Github and Gitlab issues. See `templates/README.md` for more information on
-# the templates.
-issue_body_template_file: path/to/issue_body.tmpl
-
 # a GitLab personal access token (https://gitlab.com/-/profile/personal_access_tokens), which
 # will be used to create a GitLab issue for each report. It requires
 # `api` scope. If omitted, no issues will be created.
@@ -63,3 +59,8 @@ smtp_password: myemailpass
 generic_webhook_urls: 
   - https://server.example.com/your-server/api
   - http://another-server.com/api
+
+# The paths of template files for the body of Github and Gitlab issues, and emails.
+# See `templates/README.md` for more information.
+issue_body_template_file: path/to/issue_body.tmpl
+email_body_template_file: path/to/email_body.tmpl

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -21,6 +21,19 @@ github_token: secrettoken
 github_project_mappings:
    my-app: octocat/HelloWorld
 
+# A template for the body of Github and Gitlab issues. The default template is as shown below.
+#
+# See `README.md` for more information on what can be specified here.
+issue_body_template: |
+  {{ .UserText }}
+  
+  {{ range $key, $val := .Data -}}
+  {{ $key }}: `{{ $val }}`
+  {{ end }}
+  [Logs]({{ .ListingURL }}) ([archive]({{ .ListingURL }}?format=tar.gz))
+  {{- range $file := .Files}} / [{{ $file }}]({{ $.ListingURL }}/{{ $file }})
+  {{- end }}
+
 # a GitLab personal access token (https://gitlab.com/-/profile/personal_access_tokens), which
 # will be used to create a GitLab issue for each report. It requires
 # `api` scope. If omitted, no issues will be created.
@@ -54,7 +67,6 @@ email_from: Rageshake <rageshake@matrix.org>
 smtp_server: localhost:25
 smtp_username: myemailuser
 smtp_password: myemailpass
-
 
 # a list of webhook URLs, (see docs/generic_webhook.md)
 generic_webhook_urls: 

--- a/submit.go
+++ b/submit.go
@@ -84,7 +84,7 @@ type jsonLogEntry struct {
 
 // `issueBodyTemplatePayload` contains the data made available to the `issue_body_template`.
 //
-// !!! Keep in step with the documentation in `README.md` !!!
+// !!! Keep in step with the documentation in `templates/README.md` !!!
 type issueBodyTemplatePayload struct {
 	payload
 	// Complete link to the listing URL that contains all uploaded logs
@@ -103,7 +103,7 @@ type genericWebhookPayload struct {
 // `payload` stores information about a request made to this server.
 //
 // !!! Since this is inherited by `issueBodyTemplatePayload`, remember to keep it in step
-// with the documentation in `README.md` !!!
+// with the documentation in `templates/README.md` !!!
 type payload struct {
 	// A unique ID for this payload, generated within this server 
 	ID         string            `json:"id"`

--- a/submit.go
+++ b/submit.go
@@ -687,7 +687,7 @@ func buildReportBody(p payload, newline, quoteChar string) *bytes.Buffer {
 	return &bodyBuf
 }
 
-func buildGenericIssueRequest(p payload, listingURL string, bodyTemplate *template.Template) (title, body string, err error) {
+func buildGenericIssueRequest(p payload, listingURL string, bodyTemplate *template.Template) (title string, body []byte, err error) {
 	var bodyBuf bytes.Buffer
 
 	issuePayload := issueBodyTemplatePayload{
@@ -700,7 +700,7 @@ func buildGenericIssueRequest(p payload, listingURL string, bodyTemplate *templa
 	}
 
 	title = buildReportTitle(p)
-	body = bodyBuf.String()
+	body = bodyBuf.Bytes()
 
 	return
 }
@@ -716,9 +716,10 @@ func buildGithubIssueRequest(p payload, listingURL string, bodyTemplate *templat
 	if labels == nil {
 		labels = []string{}
 	}
+	bodyStr := string(body)
 	return &github.IssueRequest{
 		Title:  &title,
-		Body:   &body,
+		Body:   &bodyStr,
 		Labels: &labels,
 	}, nil
 }
@@ -733,9 +734,10 @@ func buildGitlabIssueRequest(p payload, listingURL string, bodyTemplate *templat
 		labels = append(labels, p.Labels...)
 	}
 
+	bodyStr := string(body)
 	return &gitlab.CreateIssueOptions{
 		Title:        &title,
-		Description:  &body,
+		Description:  &bodyStr,
 		Confidential: &confidential,
 		Labels:       labels,
 	}, nil

--- a/submit_test.go
+++ b/submit_test.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"text/template"
 )
 
 // testParsePayload builds a /submit request with the given body, and calls
@@ -56,11 +57,10 @@ func testParsePayload(t *testing.T, body, contentType string, tempDir string) (*
 	return p, rr.Result()
 }
 
-
 func submitSimpleRequestToServer(t *testing.T, allowedAppNameMap map[string]bool, body string) int {
-        // Submit a request without files to the server and return statusCode
-        // Could be extended with more complicated config; aimed here just to
-        // test options for allowedAppNameMap
+	// Submit a request without files to the server and return statusCode
+	// Could be extended with more complicated config; aimed here just to
+	// test options for allowedAppNameMap
 
 	req, err := http.NewRequest("POST", "/api/submit", strings.NewReader(body))
 	if err != nil {
@@ -70,7 +70,7 @@ func submitSimpleRequestToServer(t *testing.T, allowedAppNameMap map[string]bool
 	w := httptest.NewRecorder()
 
 	var cfg config
-	s := &submitServer{nil, nil, "/", nil, nil, allowedAppNameMap, &cfg}
+	s := &submitServer{nil, nil, nil, "/", nil, nil, allowedAppNameMap, &cfg}
 
 	s.ServeHTTP(w, req)
 	rsp := w.Result()
@@ -406,6 +406,63 @@ func mkTempDir(t *testing.T) string {
  * buildGithubIssueRequest tests
  */
 
+// General test of Github issue formatting.
+func TestBuildGithubIssue(t *testing.T) {
+	body := `------WebKitFormBoundarySsdgl8Nq9voFyhdO
+Content-Disposition: form-data; name="text"
+
+
+test words.
+------WebKitFormBoundarySsdgl8Nq9voFyhdO
+Content-Disposition: form-data; name="app"
+
+riot-web
+------WebKitFormBoundarySsdgl8Nq9voFyhdO
+Content-Disposition: form-data; name="User-Agent"
+
+xxx
+------WebKitFormBoundarySsdgl8Nq9voFyhdO
+Content-Disposition: form-data; name="user_id"
+
+id
+------WebKitFormBoundarySsdgl8Nq9voFyhdO
+Content-Disposition: form-data; name="device_id"
+
+id
+------WebKitFormBoundarySsdgl8Nq9voFyhdO
+Content-Disposition: form-data; name="version"
+
+1
+------WebKitFormBoundarySsdgl8Nq9voFyhdO
+Content-Disposition: form-data; name="file"; filename="passwd.txt"
+
+file
+------WebKitFormBoundarySsdgl8Nq9voFyhdO--
+`
+	p, _ := testParsePayload(t, body,
+		"multipart/form-data; boundary=----WebKitFormBoundarySsdgl8Nq9voFyhdO",
+		"",
+	)
+
+	if p == nil {
+		t.Fatal("parseRequest returned nil")
+	}
+
+	parsedIssueTemplate := template.Must(template.New("issue").Parse(DefaultIssueBodyTemplate))
+	issueReq, err := buildGithubIssueRequest(*p, "http://test/listing/foo", parsedIssueTemplate)
+	if err != nil {
+		t.Fatalf("Error building issue request: %s", err)
+	}
+
+	if *issueReq.Title != "test words." {
+		t.Errorf("Title: got %s, want %s", *issueReq.Title, "test words.")
+	}
+	expectedBody := "User message:\n\ntest words.\n\nUser-Agent: `xxx`\nVersion: `1`\ndevice_id: `id`\nuser_id: `id`\n\n[Logs](http://test/listing/foo) ([archive](http://test/listing/foo?format=tar.gz)) / [passwd.txt](http://test/listing/foo/passwd.txt)\n"
+	if *issueReq.Body != expectedBody {
+		t.Errorf("Body: got %s, want %s", *issueReq.Body, expectedBody)
+	}
+}
+
 func TestBuildGithubIssueLeadingNewline(t *testing.T) {
 	body := `------WebKitFormBoundarySsdgl8Nq9voFyhdO
 Content-Disposition: form-data; name="text"
@@ -427,12 +484,16 @@ riot-web
 		t.Fatal("parseRequest returned nil")
 	}
 
-	issueReq := buildGithubIssueRequest(*p, "http://test/listing/foo")
+	parsedIssueTemplate := template.Must(template.New("issue").Parse(DefaultIssueBodyTemplate))
+	issueReq, err := buildGithubIssueRequest(*p, "http://test/listing/foo", parsedIssueTemplate)
+	if err != nil {
+		t.Fatalf("Error building issue request: %s", err)
+	}
 
 	if *issueReq.Title != "test words." {
 		t.Errorf("Title: got %s, want %s", *issueReq.Title, "test words.")
 	}
-	expectedBody := "User message:\n\n\ntest words.\n"
+	expectedBody := "User message:\n\ntest words.\n"
 	if !strings.HasPrefix(*issueReq.Body, expectedBody) {
 		t.Errorf("Body: got %s, want %s", *issueReq.Body, expectedBody)
 	}
@@ -453,7 +514,11 @@ Content-Disposition: form-data; name="text"
 		t.Fatal("parseRequest returned nil")
 	}
 
-	issueReq := buildGithubIssueRequest(*p, "http://test/listing/foo")
+	parsedIssueTemplate := template.Must(template.New("issue").Parse(DefaultIssueBodyTemplate))
+	issueReq, err := buildGithubIssueRequest(*p, "http://test/listing/foo", parsedIssueTemplate)
+	if err != nil {
+		t.Fatalf("Error building issue request: %s", err)
+	}
 
 	if *issueReq.Title != "Untitled report" {
 		t.Errorf("Title: got %s, want %s", *issueReq.Title, "Untitled report")
@@ -464,7 +529,7 @@ Content-Disposition: form-data; name="text"
 	}
 }
 
-func TestTestSortDataKeys(t *testing.T) {
+func TestSortDataKeys(t *testing.T) {
 	expect := `
 Number of logs: 0
 Application: 
@@ -506,9 +571,13 @@ user_id: id
 		}
 	}
 
+	parsedIssueTemplate := template.Must(template.New("issue").Parse(DefaultIssueBodyTemplate))
 	for k, v := range sample {
 		p := payload{Data: v.data}
-		res := buildGithubIssueRequest(p, "")
+		res, err := buildGithubIssueRequest(p, "", parsedIssueTemplate)
+		if err != nil {
+			t.Fatalf("Error building issue request: %s", err)
+		}
 		got := *res.Body
 		if k == 0 {
 			expect = got

--- a/submit_test.go
+++ b/submit_test.go
@@ -70,7 +70,7 @@ func submitSimpleRequestToServer(t *testing.T, allowedAppNameMap map[string]bool
 	w := httptest.NewRecorder()
 
 	var cfg config
-	s := &submitServer{nil, nil, nil, "/", nil, nil, allowedAppNameMap, &cfg}
+	s := &submitServer{nil, nil, nil, nil, "/", nil, nil, allowedAppNameMap, &cfg}
 
 	s.ServeHTTP(w, req)
 	rsp := w.Result()

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,25 @@
+This directory contains the default templates that are used by the rageshake server.
+
+The templates can be overridden via settings in the config file.
+
+The templates are as follows:
+
+* `issue_body.tmpl`: Used when filing an issue at Github or Gitlab, and gives the issue description. Override via
+  the `issue_body_template` setting in the configuration file.
+
+See https://pkg.go.dev/text/template#pkg-overview for documentation of the template language.
+
+The following properties are defined on the input (accessible via `.` or `$`):
+
+| Name         | Type                | Description                                                                                       |
+|--------------|---------------------|---------------------------------------------------------------------------------------------------|
+| `ID`         | `string`            | The unique ID for this rageshake.                                                                 |
+| `UserText`   | `string`            | A multi-line string containing the user description of the fault (from `text` in the submission). |
+| `AppName`    | `string`            | A short slug to identify the app making the report (from `app` in the submission).                |
+| `Labels`     | `[]string`          | A list of labels requested by the application.                                                    |
+| `Data`       | `map[string]string` | A map of other key/value pairs included in the submission.                                        |
+| `Logs`       | `[]string`          | A list of log file names.                                                                         |
+| `LogErrors`  | `[]string`          | Set if there are log parsing errors.                                                              |
+| `Files`      | `[]string`          | A list of other files (not logs) uploaded as part of the rageshake.                               |
+| `FileErrors` | `[]string`          | Set if there are file parsing errors.                                                             |
+| `ListingURL` | `string`            | Complete link to the listing URL that contains all uploaded logs.                                 |

--- a/templates/README.md
+++ b/templates/README.md
@@ -6,6 +6,7 @@ The templates are as follows:
 
 * `issue_body.tmpl`: Used when filing an issue at Github or Gitlab, and gives the issue description. Override via
   the `issue_body_template_file` setting in the configuration file.
+* `email_body.tmpl`: Used when sending an email. Override via the `email_body_template_file` configuration setting.
 
 See https://pkg.go.dev/text/template#pkg-overview for documentation of the template language.
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -5,7 +5,7 @@ The templates can be overridden via settings in the config file.
 The templates are as follows:
 
 * `issue_body.tmpl`: Used when filing an issue at Github or Gitlab, and gives the issue description. Override via
-  the `issue_body_template` setting in the configuration file.
+  the `issue_body_template_file` setting in the configuration file.
 
 See https://pkg.go.dev/text/template#pkg-overview for documentation of the template language.
 

--- a/templates/email_body.tmpl
+++ b/templates/email_body.tmpl
@@ -1,0 +1,9 @@
+User message:
+{{ .UserText }}
+
+{{ range $key, $val := .Data -}}
+{{ $key }}: "{{ $val }}"
+{{ end }}
+[Logs]({{ .ListingURL }}) ([archive]({{ .ListingURL }}?format=tar.gz))
+{{- range $file := .Files}} / [{{ $file }}]({{ $.ListingURL }}/{{ $file }})
+{{- end }}

--- a/templates/issue_body.tmpl
+++ b/templates/issue_body.tmpl
@@ -1,0 +1,9 @@
+User message:
+{{ .UserText }}
+
+{{ range $key, $val := .Data -}}
+{{ $key }}: `{{ $val }}`
+{{ end }}
+[Logs]({{ .ListingURL }}) ([archive]({{ .ListingURL }}?format=tar.gz))
+{{- range $file := .Files}} / [{{ $file }}]({{ $.ListingURL }}/{{ $file }})
+{{- end }}


### PR DESCRIPTION
The driver for this is that I want to add a link to our internal rageshake-search tool to the body of reported issues. Rather than add more magic special-casing that, making the format of issue bodies more configurable seems a good thing.