### PR TITLE
Reject user texts matching a regex

### DIFF
--- a/changelog.d/88.feature
+++ b/changelog.d/88.feature
@@ -1,0 +1,1 @@
+Reject user text (problem description) matching a regex and send the reason why to the client-side.

--- a/docs/blocked_rageshake.md
+++ b/docs/blocked_rageshake.md
@@ -14,6 +14,8 @@ The rageshake server you attempted to upload a report to is not accepting ragesh
 Generally, the developers who run a rageshake server will only be able to handle reports for applications they are developing,
 and your application is not listed as one of those applications.
 
+The rageshake server could also be rejecting the text you wrote in your bug report because its content matches a rejection rule. This usually happens to prevent you from disclosing private information in the bug report itself.
+
 Please contact the distributor of your application or the administrator of the web site you visit to report this as a problem.
 
 ## For developers of matrix clients

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ type RejectionCondition struct {
 	// Message sent by the user, checked only if not empty
 	UserTextMatch string `yaml:"usertext"`
 	// Send this text to the client-side to inform the user why the server rejects the rageshake. Uses a default generic value if empty.
-	UserTextMatchReason string `yaml:"reason"`
+	Reason string `yaml:"reason"`
 }
 
 // shouldReject returns true if all the App, Version, Label and UserTextMatch attributes of a RejectionCondition match
@@ -118,8 +118,8 @@ func (c RejectionCondition) shouldReject(appName, version string, labels []strin
 	// Reject by default and then accept as soon as one condition does not match
 	reject = true
 	defaultReason := "app or user text rejected"
-	if c.UserTextMatchReason != "" {
-		reason = &c.UserTextMatchReason
+	if c.Reason != "" {
+		reason = &c.Reason
 	} else {
 		reason = &defaultReason
 	}

--- a/main.go
+++ b/main.go
@@ -99,13 +99,13 @@ type config struct {
 }
 
 // RejectionCondition contains the fields that can match a bug report for it to be rejected.
+// All the (optional) fields must match for the rejection condition to apply
 type RejectionCondition struct {
-	// All the optional fields must match for the rejection condition to apply
 	// App name, checked only if not empty
 	App string `yaml:"app"`
 	// Version, checked only if not empty
 	Version string `yaml:"version"`
-	// List of labels, checked only if not empty
+	// Label, checked only if not empty
 	Label string `yaml:"label"`
 	// Message sent by the user, checked only if not empty
 	UserTextMatch string `yaml:"usertext"`

--- a/main.go
+++ b/main.go
@@ -100,15 +100,16 @@ type config struct {
 
 // RejectionCondition contains the fields that can match a bug report for it to be rejected.
 type RejectionCondition struct {
-	// If a payload is not a UserTextMatch and does not match this app name, the condition does not match.
+	// All the optional fields must match for the rejection condition to apply
+	// App name, checked only if not empty
 	App string `yaml:"app"`
-	// Optional: version that must also match in addition to the app and label. If empty, does not check version.
+	// Version, checked only if not empty
 	Version string `yaml:"version"`
-	// Optional: label that must also match in addition to the app and version. If empty, does not check label.
+	// List of labels, checked only if not empty
 	Label string `yaml:"label"`
-	// Alternative to matching app names, match the content of the user text
+	// Message sent by the user, checked only if not empty
 	UserTextMatch string `yaml:"usertext"`
-	// Send this text to the client-side to inform the user why the server rejects the rageshake
+	// Send this text to the client-side to inform the user why the server rejects the rageshake. Uses a default generic value if empty.
 	UserTextMatchReason string `yaml:"reason"`
 }
 

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func (c RejectionCondition) shouldReject(p *payload) *string {
 	return nil
 }
 
-func (c *config) matchesRejectionCondition(p *payload) (reason *string) {
+func (c *config) matchesRejectionCondition(p *payload) *string {
 	for _, rc := range c.RejectionConditions {
 		reject := rc.shouldReject(p)
 		if reject != nil {

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func (c *config) matchesRejectionCondition(p *payload) (reason *string) {
 	for _, rc := range c.RejectionConditions {
 		reject := rc.shouldReject(p)
 		if reject != nil {
-			return rc.shouldReject(p)
+			return reject
 		}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -154,12 +154,10 @@ func (c RejectionCondition) shouldReject(p *payload) *string {
 		defaultReason := "app or user text rejected"
 		if c.Reason != "" {
 			return &c.Reason
-		} else {
-			return &defaultReason
 		}
-	} else {
-		return nil
+		return &defaultReason
 	}
+	return nil
 }
 
 func (c *config) matchesRejectionCondition(p *payload) (reason *string) {

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ type RejectionCondition struct {
 }
 
 // shouldReject returns a rejection reason if the payload matches the condition, nil if the server should accept the rageshake
-// gocyclo: ignore we need lots of checks because all fields are optional
 func (c RejectionCondition) shouldReject(p *payload) (reason *string) {
 	defaultReason := "app or user text rejected"
 	if c.Reason != "" {

--- a/main.go
+++ b/main.go
@@ -117,13 +117,20 @@ type RejectionCondition struct {
 func (c RejectionCondition) shouldReject(appName, version string, labels []string, userText string) (reject bool, reason *string) {
 	// Reject by default and then accept as soon as one condition does not match
 	reject = true
-	defaultReason := "app, version, labels, user text"
+	defaultReason := "app or user text rejected"
+	if c.UserTextMatchReason != "" {
+		reason = &c.UserTextMatchReason
+	} else {
+		reason = &defaultReason
+	}
 	// Check the attribute of the RejectionCondition if it is not empty
 	if c.App != "" && c.App != appName {
-		reject = reject && false
+		reject = false
+		return
 	}
 	if c.Version != "" && c.Version != version {
-		reject = reject && false
+		reject = false
+		return
 	}
 	if c.Label != "" {
 		labelMatch := false
@@ -134,19 +141,16 @@ func (c RejectionCondition) shouldReject(appName, version string, labels []strin
 			}
 		}
 		if !labelMatch {
-			reject = reject && false
+			reject = false
+			return
 		}
 	}
 	if c.UserTextMatch != "" {
 		var userTextRegexp = regexp.MustCompile(c.UserTextMatch)
 		if !userTextRegexp.MatchString(userText) {
-			reject = reject && false
+			reject = false
+			return
 		}
-	}
-	if c.UserTextMatchReason != "" {
-		reason = &c.UserTextMatchReason
-	} else {
-		reason = &defaultReason
 	}
 	return
 }

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ type RejectionCondition struct {
 }
 
 // shouldReject returns a rejection reason if the payload matches the condition, nil if the server should accept the rageshake
+// gocyclo: ignore we need lots of checks because all fields are optional
 func (c RejectionCondition) shouldReject(p *payload) (reason *string) {
 	defaultReason := "app or user text rejected"
 	if c.Reason != "" {

--- a/main.go
+++ b/main.go
@@ -101,13 +101,13 @@ type config struct {
 // RejectionCondition contains the fields that can match a bug report for it to be rejected.
 // All the (optional) fields must match for the rejection condition to apply
 type RejectionCondition struct {
-	// App name, checked only if not empty
+	// App name, applies only if not empty
 	App string `yaml:"app"`
-	// Version, checked only if not empty
+	// Version, applies only if not empty
 	Version string `yaml:"version"`
-	// Label, checked only if not empty
+	// Label, applies only if not empty
 	Label string `yaml:"label"`
-	// Message sent by the user, checked only if not empty
+	// Message sent by the user, applies only if not empty
 	UserTextMatch string `yaml:"usertext"`
 	// Send this text to the client-side to inform the user why the server rejects the rageshake. Uses a default generic value if empty.
 	Reason string `yaml:"reason"`

--- a/main.go
+++ b/main.go
@@ -340,14 +340,5 @@ func loadConfig(configPath string) (*config, error) {
 	if err = yaml.Unmarshal(contents, &cfg); err != nil {
 		return nil, err
 	}
-	// sanity check rejection conditions
-	for _, rc := range cfg.RejectionConditions {
-		if rc.App == "" {
-			fmt.Println("rejection_condition missing an app field so will never match anything.")
-		}
-		if rc.Label == "" && rc.Version == "" {
-			fmt.Println("rejection_condition missing both label and version so will always match, specify label and/or version")
-		}
-	}
 	return &cfg, nil
 }

--- a/main.go
+++ b/main.go
@@ -117,14 +117,14 @@ type RejectionCondition struct {
 //   - if the text provided by the user matches a regex specified in the rejection condition
 //
 // If any one of these do not match the condition, it is not rejected.
-func (c RejectionCondition) shouldReject(appName, version string, labels []string, userText string) (reject bool, reason string) {
+func (c RejectionCondition) shouldReject(appName, version string, labels []string, userText string) (reject bool, reason *string) {
 	if c.App != "" {
 		if appName != c.App {
-			return false, ""
+			return false, nil
 		}
 		// version was a condition and it doesn't match => accept it
 		if version != c.Version && c.Version != "" {
-			return false, ""
+			return false, nil
 		}
 		// label was a condition and no label matches it => accept it
 		if c.Label != "" {
@@ -136,10 +136,11 @@ func (c RejectionCondition) shouldReject(appName, version string, labels []strin
 				}
 			}
 			if !labelMatch {
-				return false, ""
+				return false, nil
 			}
 		}
-		return true, "this application is not allowed to send rageshakes to this server"
+		reason := "this application is not allowed to send rageshakes to this server"
+		return true, &reason
 	}
 	if c.UserTextMatch != "" {
 		var userTextRegexp = regexp.MustCompile(c.UserTextMatch)
@@ -150,14 +151,14 @@ func (c RejectionCondition) shouldReject(appName, version string, labels []strin
 			if c.UserTextMatchReason == "" {
 				reason = "user text"
 			}
-			return true, reason
+			return true, &reason
 		}
 	}
 	// Nothing matches
-	return false, ""
+	return false, nil
 }
 
-func (c *config) matchesRejectionCondition(p *payload) (match bool, reason string) {
+func (c *config) matchesRejectionCondition(p *payload) (match bool, reason *string) {
 	for _, rc := range c.RejectionConditions {
 		version := ""
 		if p.Data != nil {
@@ -168,7 +169,7 @@ func (c *config) matchesRejectionCondition(p *payload) (match bool, reason strin
 			return true, reason
 		}
 	}
-	return false, ""
+	return false, nil
 }
 
 func basicAuth(handler http.Handler, username, password, realm string) http.Handler {

--- a/main_test.go
+++ b/main_test.go
@@ -90,13 +90,13 @@ func TestConfigRejectionCondition(t *testing.T) {
 		},
 	}
 	for _, p := range rejectPayloads {
-		reject, reason := cfg.matchesRejectionCondition(&p)
-		if reject {
-			if *reason != p.Data["ExpectedRejectReason"] {
+		reject := cfg.matchesRejectionCondition(&p)
+		if reject != nil {
+			if *reject != p.Data["ExpectedRejectReason"] {
 				t.Errorf("payload was rejected with the wrong reason:\n payload=%+v\nconfig=%+v", p, cfg)
 			}
 		}
-		if !reject {
+		if reject == nil {
 			t.Errorf("payload was accepted when it should be rejected:\n payload=%+v\nconfig=%+v", p, cfg)
 		}
 	}
@@ -150,8 +150,8 @@ func TestConfigRejectionCondition(t *testing.T) {
 		},
 	}
 	for _, p := range acceptPayloads {
-		reject, _ := cfg.matchesRejectionCondition(&p)
-		if reject {
+		reject := cfg.matchesRejectionCondition(&p)
+		if reject != nil {
 			t.Errorf("payload was rejected when it should be accepted:\n payload=%+v\nconfig=%+v", p, cfg)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -17,9 +17,14 @@ func TestConfigRejectionCondition(t *testing.T) {
 				App:     "my-app",
 				Version: "0.1.2",
 				Label:   "nightly",
+				Reason:  "no nightlies",
 			},
 			{
 				App: "block-my-app",
+			},
+			{
+				UserTextMatch: "(\\w{4}\\s){11}\\w{4}",
+				Reason:        "it matches a recovery key and recovery keys are private",
 			},
 		},
 	}
@@ -27,44 +32,69 @@ func TestConfigRejectionCondition(t *testing.T) {
 		{
 			AppName: "my-app",
 			Data: map[string]string{
-				"Version": "0.1.0",
+				"Version":              "0.1.0",
+				"ExpectedRejectReason": "app or user text rejected",
 			},
 		},
 		{
 			AppName: "my-app",
-			Data:    map[string]string{},
-			Labels:  []string{"0.1.1"},
+			Data: map[string]string{
+				"ExpectedRejectReason": "app or user text rejected",
+			},
+			Labels: []string{"0.1.1"},
 		},
 		{
 			AppName: "my-app",
 			Labels:  []string{"foo", "nightly"},
 			Data: map[string]string{
-				"Version": "0.1.2",
+				"Version":              "0.1.2",
+				"ExpectedRejectReason": "no nightlies",
 			},
 		},
 		{
 			AppName: "block-my-app",
-		},
-		{
-			AppName: "block-my-app",
-			Labels:  []string{"foo"},
-		},
-		{
-			AppName: "block-my-app",
 			Data: map[string]string{
-				"Version": "42",
+				"ExpectedRejectReason": "app or user text rejected",
 			},
 		},
 		{
 			AppName: "block-my-app",
 			Labels:  []string{"foo"},
 			Data: map[string]string{
-				"Version": "42",
+				"ExpectedRejectReason": "app or user text rejected",
+			},
+		},
+		{
+			AppName: "block-my-app",
+			Data: map[string]string{
+				"Version":              "42",
+				"ExpectedRejectReason": "app or user text rejected",
+			},
+		},
+		{
+			AppName: "block-my-app",
+			Labels:  []string{"foo"},
+			Data: map[string]string{
+				"Version":              "42",
+				"ExpectedRejectReason": "app or user text rejected",
+			},
+		},
+		{
+			AppName:  "my-app",
+			UserText: "Looks like a recover key abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd",
+			Data: map[string]string{
+				"ExpectedRejectReason": "it matches a recovery key and recovery keys are private",
 			},
 		},
 	}
 	for _, p := range rejectPayloads {
-		if !cfg.matchesRejectionCondition(&p) {
+		reject, reason := cfg.matchesRejectionCondition(&p)
+		if reject {
+			if *reason != p.Data["ExpectedRejectReason"] {
+				t.Errorf("payload was rejected with the wrong reason:\n payload=%+v\nconfig=%+v", p, cfg)
+			}
+		}
+		if !reject {
 			t.Errorf("payload was accepted when it should be rejected:\n payload=%+v\nconfig=%+v", p, cfg)
 		}
 	}
@@ -112,9 +142,14 @@ func TestConfigRejectionCondition(t *testing.T) {
 				"Version": "0.1.2",
 			},
 		},
+		{
+			AppName:  "my-app",
+			UserText: "Some description",
+		},
 	}
 	for _, p := range acceptPayloads {
-		if cfg.matchesRejectionCondition(&p) {
+		reject, _ := cfg.matchesRejectionCondition(&p)
+		if reject {
 			t.Errorf("payload was rejected when it should be accepted:\n payload=%+v\nconfig=%+v", p, cfg)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,9 @@ func TestConfigRejectionCondition(t *testing.T) {
 		{
 			AppName: "my-app",
 			Data: map[string]string{
-				"Version":              "0.1.0",
+				"Version": "0.1.0",
+				// Hack add how we expect the rageshake to be rejected to the test
+				// The actual data in a rageshake has no ExpectedRejectReason field
 				"ExpectedRejectReason": "app or user text rejected",
 			},
 		},

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -23,6 +23,8 @@ rejection_conditions:
   - app: my-app
     version: "0.4.9"
     label: "nightly" # both label and Version must match for this condition to be true
+  - app: whatever
+    usertextmatch: "(\\w{4}\\s){11}\\w{4}"
 
 # a GitHub personal access token (https://github.com/settings/tokens), which
 # will be used to create a GitHub issue for each report. It requires

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -13,8 +13,11 @@ listings_auth_pass: secret
 allowed_app_names: []
 
 # If any submission matches one of these rejection conditions, the submission is rejected.
-# The 'app' field is required, but 'version' and 'label' are both optional. A condition with just
-# an 'app' will reject that app altogether, effectively acting as a blocklist for app in contrast to allowed_app_names.
+# You can either match an 'app' name, with optional 'version' and 'label' or the 'usertext' submitted by the user when describing their issue.
+#
+# Adding an 'app' item will reject that app altogether, effectively acting as a blocklist for app in contrast to allowed_app_names. You can optionally add 'version' and 'label' to fine-tune the rejection condition
+#
+# 'usertext' is a regex to reject user descriptions with an optional 'reason' text to send to the client
 rejection_conditions:
   - app: my-app
     version: "0.4.9" # if the submission has a Version which is exactly this value, reject the submission.
@@ -23,7 +26,8 @@ rejection_conditions:
   - app: my-app
     version: "0.4.9"
     label: "nightly" # both label and Version must match for this condition to be true
-  - usertextmatch: "(\\w{4}\\s){11}\\w{4}" # reject text containing possible recovery keys
+  - usertext: "(\\w{4}\\s){11}\\w{4}" # reject text containing possible recovery keys
+    reason: "it matches a recovery key and recovery keys are private"
 
 # a GitHub personal access token (https://github.com/settings/tokens), which
 # will be used to create a GitHub issue for each report. It requires

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -23,8 +23,7 @@ rejection_conditions:
   - app: my-app
     version: "0.4.9"
     label: "nightly" # both label and Version must match for this condition to be true
-  - app: whatever
-    usertextmatch: "(\\w{4}\\s){11}\\w{4}"
+  - usertextmatch: "(\\w{4}\\s){11}\\w{4}" # reject text containing possible recovery keys
 
 # a GitHub personal access token (https://github.com/settings/tokens), which
 # will be used to create a GitHub issue for each report. It requires

--- a/rageshake.sample.yaml
+++ b/rageshake.sample.yaml
@@ -13,11 +13,8 @@ listings_auth_pass: secret
 allowed_app_names: []
 
 # If any submission matches one of these rejection conditions, the submission is rejected.
-# You can either match an 'app' name, with optional 'version' and 'label' or the 'usertext' submitted by the user when describing their issue.
-#
-# Adding an 'app' item will reject that app altogether, effectively acting as a blocklist for app in contrast to allowed_app_names. You can optionally add 'version' and 'label' to fine-tune the rejection condition
-#
-# 'usertext' is a regex to reject user descriptions with an optional 'reason' text to send to the client
+# A condition is made by an union of optional fields: app, version, labels, user text. They all need to match for rejecting the rageshake
+# It can also contain an optional reason to explain why this server is rejecting a user's submission.
 rejection_conditions:
   - app: my-app
     version: "0.4.9" # if the submission has a Version which is exactly this value, reject the submission.
@@ -26,6 +23,7 @@ rejection_conditions:
   - app: my-app
     version: "0.4.9"
     label: "nightly" # both label and Version must match for this condition to be true
+    reason: "this server does not accept rageshakes from nightlies"
   - usertext: "(\\w{4}\\s){11}\\w{4}" # reject text containing possible recovery keys
     reason: "it matches a recovery key and recovery keys are private"
 

--- a/submit.go
+++ b/submit.go
@@ -228,12 +228,12 @@ func (s *submitServer) handleSubmission(w http.ResponseWriter, req *http.Request
 	}
 	matchesRejection, reason := s.cfg.matchesRejectionCondition(p)
 	if matchesRejection {
-		log.Printf("Blocking rageshake from app %s because it matches a rejection_condition: %s", p.AppName, reason)
+		log.Printf("Blocking rageshake from app %s because it matches a rejection_condition: %s", p.AppName, *reason)
 		if err := os.RemoveAll(reportDir); err != nil {
 			log.Printf("Unable to remove report dir %s after rejected upload: %v\n",
 				reportDir, err)
 		}
-		userErrorText := fmt.Sprintf("This server did not accept the rageshake because it matches a rejection condition: %s. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", reason)
+		userErrorText := fmt.Sprintf("This server did not accept the rageshake because it matches a rejection condition: %s. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", *reason)
 		http.Error(w, userErrorText, 400)
 		return
 	}

--- a/submit.go
+++ b/submit.go
@@ -226,13 +226,15 @@ func (s *submitServer) handleSubmission(w http.ResponseWriter, req *http.Request
 		http.Error(w, "This server does not accept rageshakes from your application. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", 400)
 		return
 	}
-	if s.cfg.matchesRejectionCondition(p) {
-		log.Printf("Blocking rageshake from app %s because it matches a rejection_condition", p.AppName)
+	matchesRejection, reason := s.cfg.matchesRejectionCondition(p)
+	if matchesRejection {
+		log.Printf("Blocking rageshake from app %s because it matches a rejection_condition: %s", p.AppName, reason)
 		if err := os.RemoveAll(reportDir); err != nil {
 			log.Printf("Unable to remove report dir %s after rejected upload: %v\n",
 				reportDir, err)
 		}
-		http.Error(w, "This server does not accept rageshakes from your application + version. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", 400)
+		userErrorText := fmt.Sprintf("This server did not accept the rageshake because it matches a rejection condition: %s. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", reason)
+		http.Error(w, userErrorText, 400)
 		return
 	}
 

--- a/submit.go
+++ b/submit.go
@@ -226,14 +226,14 @@ func (s *submitServer) handleSubmission(w http.ResponseWriter, req *http.Request
 		http.Error(w, "This server does not accept rageshakes from your application. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", 400)
 		return
 	}
-	matchesRejection, reason := s.cfg.matchesRejectionCondition(p)
-	if matchesRejection {
-		log.Printf("Blocking rageshake from app %s because it matches a rejection_condition: %s", p.AppName, *reason)
+	rejection := s.cfg.matchesRejectionCondition(p)
+	if rejection != nil {
+		log.Printf("Blocking rageshake from app %s because it matches a rejection_condition: %s", p.AppName, *rejection)
 		if err := os.RemoveAll(reportDir); err != nil {
 			log.Printf("Unable to remove report dir %s after rejected upload: %v\n",
 				reportDir, err)
 		}
-		userErrorText := fmt.Sprintf("This server did not accept the rageshake because it matches a rejection condition: %s. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", *reason)
+		userErrorText := fmt.Sprintf("This server did not accept the rageshake because it matches a rejection condition: %s. See https://github.com/matrix-org/rageshake/blob/master/docs/blocked_rageshake.md", *rejection)
 		http.Error(w, userErrorText, 400)
 		return
 	}


### PR DESCRIPTION
Sometimes users send something they really should not in their rageshake descriptions. I propose here an approach to reject rageshakes whose description matches a regex. The rejection reason is reflected client-side so the user's client can show them want went wrong.

The sample config file provides a regex to reject user texts that could contain a recovery key.

TODO if we like this approach:
- [x] Update `docs/blocked_rageshake.md`
- [x] Update `main_test.go`
- <del>Update `submit_test.go`</del>
- [x] Update changelog
