### PR TITLE
Clarify the omission of report_url in the response.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -78,7 +78,7 @@ logs.)
 The response (if successful) will be a JSON object with the following fields:
 
 * `report_url`: A URL where the user can track their bug report. Omitted if
-  issue submission was disabled.
+  issue submission (to GitHub/GitLab) was disabled.
 
 ## Error responses
 


### PR DESCRIPTION
Coming to these docs without knowing the project, this sounded to me like "if rageshakes are disabled, the field will be omitted" as I was unaware until looking at [the code](https://github.com/matrix-org/rageshake/blob/af89ac135d489d182627c4d36971472a3078cc1c/submit.go#L107-L108) that you can run a rageshake server that doesn't then create GitHub/GitLab issues.